### PR TITLE
feat: add cloudflare accountId option to the generator schema

### DIFF
--- a/packages/plugins/nx-cloudflare/README.md
+++ b/packages/plugins/nx-cloudflare/README.md
@@ -51,6 +51,7 @@ The available options are the following:
 | name            | string                                 | \*required    | What name would you like to use?                                                          |
 | template        | fetch-handler, scheduled-handler, none | fetch-handler | Which worker template do you want to use?                                                 |
 | port            | number                                 | 8787          | The port in which the worker will be run on development mode                              |
+| accountId       | string                                 | null          | The Cloudflare account identifier where the worker will be deployed                       |
 | js              | boolean                                | false         | Use JavaScript instead of TypeScript                                                      |
 | tags            | string                                 | null          | Add tags to the application (used for linting).                                           |
 | frontendProject | string                                 | null          | Frontend project that needs to access this application. This sets up proxy configuration. |

--- a/packages/plugins/nx-cloudflare/src/generators/application/application.spec.ts
+++ b/packages/plugins/nx-cloudflare/src/generators/application/application.spec.ts
@@ -187,6 +187,7 @@ describe('app', () => {
 compatibility_date = "2023-07-31"
 main = "src/index.ts"
 
+
 "
 `);
     });
@@ -456,6 +457,25 @@ main = "src/index.ts"
 "name = "my-worker-app"
 compatibility_date = "2023-07-31"
 main = "src/index.js"
+
+
+"
+`);
+    });
+
+    it('should add the account_id field to wrangler.toml when specified', async () => {
+      const accountId = 'fake40q5pchj988766d696c1ajek9mcd';
+      await applicationGenerator(tree, {
+        name: 'myWorkerApp',
+        js: true,
+        accountId,
+      });
+      expect(tree.read('my-worker-app/wrangler.toml', 'utf-8'))
+        .toMatchInlineSnapshot(`
+"name = "my-worker-app"
+compatibility_date = "2023-07-31"
+main = "src/index.js"
+account_id = "${accountId}"
 
 "
 `);

--- a/packages/plugins/nx-cloudflare/src/generators/application/application.ts
+++ b/packages/plugins/nx-cloudflare/src/generators/application/application.ts
@@ -18,6 +18,7 @@ import type { NormalizedSchema, Schema } from './schema';
 import { join } from 'path';
 import initGenerator from '../init/init';
 import { vitestImports } from './utils/vitest-imports';
+import { getAccountId } from './utils/get-account-id';
 
 function updateTsAppConfig(tree: Tree, options: NormalizedSchema) {
   updateJson(
@@ -69,6 +70,7 @@ function addCloudflareFiles(tree: Tree, options: NormalizedSchema) {
       tmpl: '',
       name: options.name,
       extension: options.js ? 'js' : 'ts',
+      accountId: options.accountId ? getAccountId(options.accountId) : '',
     }
   );
 

--- a/packages/plugins/nx-cloudflare/src/generators/application/files/common/wrangler.toml__tmpl__
+++ b/packages/plugins/nx-cloudflare/src/generators/application/files/common/wrangler.toml__tmpl__
@@ -1,4 +1,5 @@
 name = "<%=name %>"
 compatibility_date = "2023-07-31"
 main = "src/index.<%=extension %>"
+<%-accountId %>
 

--- a/packages/plugins/nx-cloudflare/src/generators/application/schema.d.ts
+++ b/packages/plugins/nx-cloudflare/src/generators/application/schema.d.ts
@@ -9,6 +9,7 @@ export interface Schema {
   frontendProject?: string;
   skipFormat?: boolean;
   port?: number;
+  accountId?: string;
 }
 
 export interface NormalizedSchema extends Schema {

--- a/packages/plugins/nx-cloudflare/src/generators/application/schema.json
+++ b/packages/plugins/nx-cloudflare/src/generators/application/schema.json
@@ -45,6 +45,10 @@
       "type": "number",
       "default": 8787
     },
+    "accountId": {
+      "description": "The Cloudflare account identifier where the worker will be deployed",
+      "type": "string"
+    },
     "directory": {
       "description": "The directory of the new application.",
       "type": "string",

--- a/packages/plugins/nx-cloudflare/src/generators/application/utils/get-account-id.ts
+++ b/packages/plugins/nx-cloudflare/src/generators/application/utils/get-account-id.ts
@@ -1,0 +1,3 @@
+export function getAccountId(accountId: string): string {
+  return `account_id = "${accountId}"`;
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The accountId is necessary for deploying the worker, and we are not providing an option to define it.

## What is the new behavior?

We define the accountId on the schema, and if present we added the `account_id` to the wrangler.toml

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```