### PR TITLE
fix: next-on-pages executor

### DIFF
--- a/e2e/plugins-nx-cloudflare-e2e/tests/next-on-pages.spec.ts
+++ b/e2e/plugins-nx-cloudflare-e2e/tests/next-on-pages.spec.ts
@@ -7,29 +7,26 @@ import {
   updateFile,
 } from '@nx/plugin/testing';
 
+const workerapp = uniq('workerapp');
+
 describe('Next on Pages', () => {
   beforeEach(() => {
     ensureNxProject(
       '@naxodev/nx-cloudflare',
       'dist/packages/plugins/nx-cloudflare'
     );
+
+    runNxCommand(
+      `generate @nx/next:app --name ${workerapp} --directory="apps" --appDir`
+    );
   });
 
   afterEach(() => cleanup());
 
   it('should build a NextJS application with the next-on-pages script', async () => {
-    const workerapp = uniq('workerapp');
-
-    runNxCommand(
-      `generate @nx/next:app --name ${workerapp} --directory="apps" --appDir`
-    );
-
     const projectJson = readJson(`apps/${workerapp}/project.json`);
     projectJson.targets.build.executor = '@naxodev/nx-cloudflare:next-build';
-    console.log('file to update', projectJson);
     updateFile(`apps/${workerapp}/project.json`, JSON.stringify(projectJson));
-
-    console.log('updated file', readJson(`apps/${workerapp}/project.json`));
 
     const buildResults = runNxCommand(`build ${workerapp}`);
     expect(buildResults).toContain(

--- a/e2e/plugins-nx-cloudflare-e2e/tests/next-on-pages.spec.ts
+++ b/e2e/plugins-nx-cloudflare-e2e/tests/next-on-pages.spec.ts
@@ -1,13 +1,11 @@
 import {
   uniq,
-  tmpProjPath,
   runNxCommand,
   ensureNxProject,
   cleanup,
   readJson,
   updateFile,
 } from '@nx/plugin/testing';
-import { join } from 'path';
 
 describe('Next on Pages', () => {
   beforeEach(() => {
@@ -21,20 +19,17 @@ describe('Next on Pages', () => {
 
   it('should build a NextJS application with the next-on-pages script', async () => {
     const workerapp = uniq('workerapp');
-    const port = 8787;
 
     runNxCommand(
       `generate @nx/next:app --name ${workerapp} --directory="apps" --appDir`
     );
 
-    const projectJson = readJson(
-      join(tmpProjPath(), `apps/${workerapp}/project.json`)
-    );
+    const projectJson = readJson(`apps/${workerapp}/project.json`);
     projectJson.targets.build.executor = '@naxodev/nx-cloudflare:next-build';
-    updateFile(
-      join(tmpProjPath(), `apps/${workerapp}/project.json`),
-      JSON.stringify(projectJson)
-    );
+    console.log('file to update', projectJson);
+    updateFile(`apps/${workerapp}/project.json`, JSON.stringify(projectJson));
+
+    console.log('updated file', readJson(`apps/${workerapp}/project.json`));
 
     const buildResults = runNxCommand(`build ${workerapp}`);
     expect(buildResults).toContain(

--- a/e2e/plugins-nx-cloudflare-e2e/tests/next-on-pages.ts
+++ b/e2e/plugins-nx-cloudflare-e2e/tests/next-on-pages.ts
@@ -1,0 +1,44 @@
+import {
+  uniq,
+  tmpProjPath,
+  runNxCommand,
+  ensureNxProject,
+  cleanup,
+  readJson,
+  updateFile,
+} from '@nx/plugin/testing';
+import { join } from 'path';
+
+describe('Next on Pages', () => {
+  beforeEach(() => {
+    ensureNxProject(
+      '@naxodev/nx-cloudflare',
+      'dist/packages/plugins/nx-cloudflare'
+    );
+  });
+
+  afterEach(() => cleanup());
+
+  it('should build a NextJS application with the next-on-pages script', async () => {
+    const workerapp = uniq('workerapp');
+    const port = 8787;
+
+    runNxCommand(
+      `generate @nx/next:app --name ${workerapp} --directory="apps" --appDir`
+    );
+
+    const projectJson = readJson(
+      join(tmpProjPath(), `apps/${workerapp}/project.json`)
+    );
+    projectJson.targets.build.executor = '@naxodev/nx-cloudflare:next-build';
+    updateFile(
+      join(tmpProjPath(), `apps/${workerapp}/project.json`),
+      JSON.stringify(projectJson)
+    );
+
+    const buildResults = runNxCommand(`build ${workerapp}`);
+    expect(buildResults).toContain(
+      `NX   Successfully ran target build for project ${workerapp}`
+    );
+  }, 120_000);
+});

--- a/packages/plugins/nx-cloudflare/package.json
+++ b/packages/plugins/nx-cloudflare/package.json
@@ -41,8 +41,7 @@
     "webpack": "^5.88.2",
     "nx": "^17.0.0",
     "@nx/workspace": "^17.0.0",
-    "@nx/web": "^17.0.0",
-    "@cloudflare/next-on-pages": "^1.6.3"
+    "@nx/web": "^17.0.0"
   },
   "dependencies": {
     "@nx/devkit": "^17.0.0",

--- a/packages/plugins/nx-cloudflare/src/executors/next-build/build.impl.ts
+++ b/packages/plugins/nx-cloudflare/src/executors/next-build/build.impl.ts
@@ -3,14 +3,20 @@ import 'dotenv/config';
 import {
   detectPackageManager,
   ExecutorContext,
+  getPackageManagerCommand,
   logger,
   readJsonFile,
-  workspaceRoot,
   writeJsonFile,
 } from '@nx/devkit';
 import { createLockFile, createPackageJson, getLockFileName } from '@nx/js';
-import { join, resolve as pathResolve } from 'path';
-import { copySync, existsSync, mkdir, writeFileSync } from 'fs-extra';
+import { join } from 'path';
+import {
+  copySync,
+  ensureDirSync,
+  existsSync,
+  mkdir,
+  writeFileSync,
+} from 'fs-extra';
 import { gte } from 'semver';
 import { directoryExists } from '@nx/workspace/src/utilities/fileutils';
 import { checkAndCleanWithSemver } from '@nx/devkit/src/utils/semver';
@@ -19,15 +25,15 @@ import { updatePackageJson } from './lib/update-package-json';
 import { createNextConfigFile } from './lib/create-next-config-file';
 import { checkPublicDirectory } from './lib/check-project';
 import { NextBuildBuilderOptions } from '../../utils/types';
-import { ChildProcess, fork } from 'child_process';
+import { execSync, ExecSyncOptions } from 'child_process';
 import { createCliOptions } from '../../utils/create-cli-options';
-
-let childProcess: ChildProcess;
 
 // This executor is a modified version of the original `@nrwl/next:build` executor.
 // It's main modification is to use the cloudflare next-on-pages package.
 // Because the Cloudflare builder doesn't allow us to locate the build output outside the project root directory
 // we need to change the output path config options to the project root directory and then copy the build output to the desired output path.
+// We also move from invoking the bin script to executing the command with the `execSync` function. This is because the bin script
+// is not exported on the package.json
 export default async function buildExecutor(
   options: NextBuildBuilderOptions,
   context: ExecutorContext
@@ -54,21 +60,18 @@ export default async function buildExecutor(
   if (hasReact18) {
     process.env['__NEXT_REACT_ROOT'] ||= 'true';
   }
+  ensureDirSync(join(projectRoot, '.vercel'));
 
   const { outputPath: originalOutputPath } = options;
   // Set the outputPath to the projectRoot to bypass cloudflare builded limitations.
   options.outputPath = projectRoot;
 
   try {
-    await runCliBuild(workspaceRoot, projectRoot, options);
+    runCliBuild(projectRoot, options);
   } catch (error) {
     logger.error(`Error occurred while trying to run the build command`);
     logger.error(error);
     return { success: false };
-  } finally {
-    if (childProcess) {
-      childProcess.kill();
-    }
   }
 
   if (!directoryExists(options.outputPath)) {
@@ -130,11 +133,7 @@ export default async function buildExecutor(
   return { success: true };
 }
 
-function runCliBuild(
-  workspaceRoot: string,
-  projectRoot: string,
-  options: NextBuildBuilderOptions
-) {
+function runCliBuild(projectRoot: string, options: NextBuildBuilderOptions) {
   const { experimentalAppOnly, profile, debug, outputPath } = options;
 
   // Set output path here since it can also be set via CLI
@@ -142,31 +141,16 @@ function runCliBuild(
   process.env.NX_NEXT_OUTPUT_PATH ??= outputPath;
 
   const args = createCliOptions({ experimentalAppOnly, profile, debug });
-  return new Promise((resolve, reject) => {
-    childProcess = fork(
-      require.resolve('@cloudflare/next-on-pages/bin'),
-      [...args],
-      {
-        cwd: pathResolve(workspaceRoot, projectRoot),
-        stdio: 'inherit',
-        env: process.env,
-      }
-    );
 
-    // Ensure the child process is killed when the parent exits
-    process.on('exit', () => childProcess.kill());
-    process.on('SIGTERM', () => childProcess.kill());
+  const pmc = getPackageManagerCommand('npm');
+  const execSyncOptions: ExecSyncOptions = {
+    stdio: ['inherit', 'inherit', 'inherit'],
+    encoding: 'utf-8',
+    cwd: projectRoot,
+  };
 
-    childProcess.on('error', (err) => {
-      reject(err);
-    });
-
-    childProcess.on('exit', (code) => {
-      if (code === 0) {
-        resolve(code);
-      } else {
-        reject(code);
-      }
-    });
-  });
+  execSync(
+    `${pmc.exec} @cloudflare/next-on-pages ${args.join(' ')}`,
+    execSyncOptions
+  );
 }

--- a/tools/scripts/start-local-registry.ts
+++ b/tools/scripts/start-local-registry.ts
@@ -19,7 +19,7 @@ export default async () => {
   const nx = require.resolve('nx');
   execFileSync(
     nx,
-    ['run-many', '--targets', 'publish', '--ver', '999.0.0', '--tag', 'e2e'],
+    ['run-many', '--targets', 'publish', '--ver', '0.0.0-e2e', '--tag', 'e2e'],
     { env: process.env, stdio: 'inherit' }
   );
 };


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

`next-on-pages` doesn't export the "bin/index.js' script on the package.json, which causes the @naxodev/nx-cloudflare:next-build* executor to fail.

Fixes: #30 

## What is the new behavior?

We execute the `next-on-pages` package with 'nox' in CLI mode as it was designed to be used.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information

- We tried loading the script directly by finding its directory, and this worked partially but threw with the following error:

```zsh
⚡️ @cloudflare/next-on-pages CLI v.1.7.3
    ⚡️ Detected Package Manager: pnpm (8.7.1)
    ⚡️ Preparing project...
    ⚡️ Project is ready
    ⚡️ Building project...
    ▲  Progress: resolved 1, reused 0, downloaded 0, added 0
    ▲  .../Library/pnpm/store/v3/tmp/dlx-82210  |  WARN  deprecated debug@4.1.1
    ▲  .../Library/pnpm/store/v3/tmp/dlx-82210  |  WARN  deprecated uuid@3.3.2
    ▲  .../Library/pnpm/store/v3/tmp/dlx-82210  |  WARN  deprecated fsevents@2.1.3
    ▲  Packages: +247
    ▲  ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
    ▲  Progress: resolved 266, reused 247, downloaded 0, added 121
    ▲  Progress: resolved 266, reused 247, downloaded 0, added 247, done
    ▲  Vercel CLI 32.5.5
    ▲  Detected `pnpm-lock.yaml` version 6 generated by pnpm 8
    ▲  Your application is being built using `next build`. If you need to define a different build step, please create a `vercel-build` script in your `package.json` (e.g. `{ "scripts": { "vercel-build": "npm run prepare && next build" } }`).
    ▲  Installing dependencies...
    ▲  Already up to date
    ▲
    ▲  Done in 257ms
    ▲  Detected Next.js version: 14.0.3
    ▲  Running "pnpm run vercel-build"
    ▲  > @ vercel-build /Users/nachovazquez/work/1-projects/naxodev/oss/tmp/nx-e2e/proj/apps/workerapp6167759
    ▲  > next build
    ▲  sh: next: command not found
    ▲   ELIFECYCLE  Command failed.
    ▲   WARN   Local package.json exists, but node_modules missing, did you mean to install?
    ▲  Error: Command "pnpm run vercel-build" exited with 1
```

We also tried executing the command based on the package manager used, but it did the same for `pnpx`.

`npx` is globally available and works, so we chose it.