### PR TITLE
fix: Accept empty plugin options for gonx

### DIFF
--- a/packages/gonx/src/graph/utils/create-nodes-internal.ts
+++ b/packages/gonx/src/graph/utils/create-nodes-internal.ts
@@ -6,7 +6,7 @@ import { getTargetsByProjectType } from './targets/get-targets-by-project-type';
 
 export function createNodesInternal(
   configFilePath: string,
-  options: GoPluginOptions,
+  options: GoPluginOptions = {},
   // context is not used, but TypeScript needs the parameter
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   context: CreateNodesContextV2


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Plugin crashes if no options provided when declaring it in `nx.json`. For instance, when using it as:
```json
"plugins": {
  "@naxodev/gonx",
  // ...
}
```  

## What is the new behavior?

Plugin can be declared with no options passed.

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
