### PR TITLE
fix(nx-cloudflare/serve): make PWD absolute to silence Wrangler warning

### DIFF
--- a/packages/nx-cloudflare/src/executors/serve/executor.ts
+++ b/packages/nx-cloudflare/src/executors/serve/executor.ts
@@ -1,5 +1,6 @@
 import { ExecutorContext } from '@nx/devkit';
-import { ServeSchema } from './schema';
+import { ServeSchema } from './schema
+import { join } from 'path';
 import { fork } from 'child_process';
 import { createAsyncIterable } from '@nx/devkit/src/utils/async-iterable';
 import { waitForPortOpen } from '@nx/web/src/utils/wait-for-port-open';
@@ -18,7 +19,7 @@ export default async function* serveExecutor(
 
   yield* createAsyncIterable<{ success: boolean; baseUrl: string }>(
     async ({ done, next, error }) => {
-      process.env.PWD = projectRoot;
+      process.env.PWD = join(process.cwd(), projectRoot);
       const server = fork(wranglerBin, ['dev', ...wranglerOptions], {
         cwd: projectRoot,
         stdio: 'inherit',


### PR DESCRIPTION
Wrangler warns when PWD does not start with "/". In some shells/CI, PWD may be unset or relative, triggering the warning.

Always provide an absolute PWD: prefer process.cwd(); if env.PWD is set but not absolute, resolve it to an absolute path before passing to Wrangler. This removes the warning and normalizes path handling.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When running wrangler a warning is thrown about the pwd not beginning with `/`, wranger prefers to have an absolute path, everything worked fine, but the warning cluttered up the terminal.

Issue Number: N/A

## What is the new behavior?

When running the serve executor it will always build a complete path to the project by prefixing `process.cwd()` onto the path, and uses the `join` function from the nodejs `path` package to ensure it has the appropriate path. 

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
