### PR TITLE
refactor(gonx): use static p-limit import

### DIFF
--- a/packages/gonx/src/graph/create-dependencies.spec.ts
+++ b/packages/gonx/src/graph/create-dependencies.spec.ts
@@ -1,4 +1,10 @@
-jest.mock('./static-analysis');
+// Explicit factory (not auto-mock) so Jest does not load the real
+// `./static-analysis` module — that module statically imports `p-limit`
+// (ESM-only), and ts-jest would resolve the require at module-load time
+// before any per-test `jest.mock('p-limit', ...)` could intercept it.
+jest.mock('./static-analysis', () => ({
+  createStaticAnalysisDependencies: jest.fn(),
+}));
 
 import { DependencyType } from '@nx/devkit';
 import { createDependencies } from './create-dependencies';

--- a/packages/gonx/src/graph/static-analysis/index.ts
+++ b/packages/gonx/src/graph/static-analysis/index.ts
@@ -9,6 +9,7 @@ import {
   workspaceRoot,
 } from '@nx/devkit';
 import { normalizePath } from 'nx/src/utils/path';
+import pLimit from 'p-limit';
 import { join } from 'path';
 import { GoPluginOptions } from '../types/go-plugin-options';
 import { buildImportMap } from './build-import-map';
@@ -48,15 +49,6 @@ export async function createStaticAnalysisDependencies(
   const projectsToProcess = Object.keys(context.filesToProcess.projectFileMap);
 
   // Process projects with concurrency limit.
-  // p-limit v4+ is ESM-only and ts-jest compiles a static `import` to a hard
-  // `require()` evaluated at module load — any spec that touches this chain
-  // via `jest.mock('./static-analysis')` (auto-mock loads the real module to
-  // discover exports) then fails to parse p-limit's ESM source. Loading it
-  // lazily via dynamic import keeps the module-load path test-tooling-safe;
-  // ts-jest lowers `await import()` to a deferred `Promise.resolve().then(
-  // () => require(...))` that only runs when the function executes, by which
-  // point the spec's explicit `jest.mock('p-limit', ...)` has been hoisted.
-  const pLimit = (await import('p-limit')).default;
   const limit = pLimit(10);
   await Promise.all(
     projectsToProcess.map((projectName) =>


### PR DESCRIPTION
Closes #103.

## What

- `packages/gonx/src/graph/static-analysis/index.ts` — replace `await import('p-limit')` with a top-level static `import pLimit from 'p-limit'`. Drop the workaround comment.
- `packages/gonx/src/graph/create-dependencies.spec.ts` — replace the bare `jest.mock('./static-analysis')` (auto-mock, which loads the real module to discover exports) with an explicit factory that returns just `{ createStaticAnalysisDependencies: jest.fn() }`. Add a short comment explaining the choice.

## Why

The dynamic import existed because `create-dependencies.spec.ts`'s auto-mock was loading the real `./static-analysis` module, and ts-jest resolves a static `require('p-limit')` at module-load time — before any per-test `jest.mock('p-limit', ...)` is hoisted. The mock-factory fix removes that load entirely from this spec; `index.spec.ts` already mocks `p-limit` explicitly, so it's unaffected.

Removes a code smell flagged in CLAUDE.md ("Avoid using dynamic imports when possible"). Net -2 lines.

## Verification

- `nx test gonx` → 216/216 pass (unchanged from baseline)
- `tsc --noEmit -p packages/gonx/tsconfig.lib.json` → clean
- `tsc --noEmit -p packages/gonx/tsconfig.spec.json` → clean
- `nx lint gonx` → 0 errors (61 pre-existing warnings unchanged)

## Runtime compatibility

Node 22.12+ supports `require()` of synchronous ESM modules, and the project pins Node 22 (`.nvmrc`). Verified locally on Node 22.18 that `require('p-limit')` resolves the default export correctly.