### PR TITLE
feat(gonx): evaluate Go build tags during static analysis

### DIFF
--- a/packages/gonx/docs/static-analysis.md
+++ b/packages/gonx/docs/static-analysis.md
@@ -44,16 +44,39 @@ In your `nx.json`:
 | ----------------------- | ------- | ------- | ------------------------------------- |
 | `skipGoDependencyCheck` | boolean | `false` | Disable dependency detection entirely |
 
+## Build constraints
+
+`//go:build` and legacy `// +build` constraints are honored. The dep
+graph is computed against the host platform's GOOS/GOARCH — a file
+gated to a different platform contributes no edges on the host.
+
+Supported in the constraint expression:
+
+- `//go:build` modern boolean form: `&&`, `||`, `!`, parens
+- `// +build` legacy form (space-separated terms = OR, comma-separated
+  within a term = AND, `!` per-term negation, multiple lines AND'd)
+- `unix` pseudo-tag (matches Linux, Darwin, BSDs, Solaris, AIX, etc.)
+- GOOS values (`linux`, `darwin`, `windows`, …) and GOARCH values
+  (`amd64`, `arm64`, `386`, …)
+- User-defined tags via the `BuildContext.tags` set (internal API; no
+  plugin option yet)
+
+Behavior on edge cases:
+
+- `go1.X` version tags evaluate to `true` (we have no Go compiler
+  handy to consult; over-including is safer than under-including for
+  graph purposes).
+- The `cgo` pseudo-tag evaluates to `false` — static analysis never
+  invokes cgo.
+- A malformed expression falls back to "include the file" rather than
+  failing graph construction.
+
 ## Limitations
 
-- **No build tag support**: All `.go` files are parsed regardless of
-  `//go:build` constraints. This may include platform-specific
-  dependencies that wouldn't be compiled in practice. Cross-platform
-  code with OS-specific files (e.g. `foo_linux.go` and `foo_windows.go`
-  importing different sibling projects) will produce the **union** of
-  edges across all build tags. This can introduce false dependency
-  cycles between projects that are acyclic on any individual platform —
-  worth checking if you see unexpected cycles in `nx graph`.
+- **Filename-based constraints are not honored.** Files like
+  `foo_linux.go` or `bar_amd64.go` are always parsed regardless of
+  whether their filename suffix matches the host. Only in-source
+  `//go:build` / `// +build` lines are evaluated.
 
 - **No cgo support**: The `import "C"` pseudo-import is filtered out.
 

--- a/packages/gonx/docs/static-analysis.md
+++ b/packages/gonx/docs/static-analysis.md
@@ -55,11 +55,25 @@ Supported in the constraint expression:
 - `//go:build` modern boolean form: `&&`, `||`, `!`, parens
 - `// +build` legacy form (space-separated terms = OR, comma-separated
   within a term = AND, `!` per-term negation, multiple lines AND'd)
-- `unix` pseudo-tag (matches Linux, Darwin, BSDs, Solaris, AIX, etc.)
+- `unix` pseudo-tag (matches Linux, Darwin, the BSDs, Solaris, AIX, and
+  — note — Android, illumos, iOS, dragonfly, hurd; the full set Go ships
+  in `internal/syslist.UnixOS`)
 - GOOS values (`linux`, `darwin`, `windows`, …) and GOARCH values
   (`amd64`, `arm64`, `386`, …)
-- User-defined tags via the `BuildContext.tags` set (internal API; no
-  plugin option yet)
+- User-defined tags via the `BuildContext.tags` set (internal API; a
+  plugin-option surface is tracked in [#108](https://github.com/naxodev/oss/issues/108))
+
+Filename-based suffixes are also honored, matching Go's `go/build`
+algorithm:
+
+- `name_<GOOS>.go` — gates on GOOS (e.g. `signal_linux.go`)
+- `name_<GOARCH>.go` — gates on GOARCH (e.g. `sha1block_amd64.go`)
+- `name_<GOOS>_<GOARCH>.go` — gates on both (e.g. `zsyscall_darwin_arm64.go`)
+- Any of the above with a trailing `_test` before `.go`
+
+Note that `unix` is recognized only as an in-source build tag, **not** as
+a filename suffix — Go itself doesn't treat `foo_unix.go` as
+unix-gated, and neither do we.
 
 Behavior on edge cases:
 
@@ -72,11 +86,6 @@ Behavior on edge cases:
   failing graph construction.
 
 ## Limitations
-
-- **Filename-based constraints are not honored.** Files like
-  `foo_linux.go` or `bar_amd64.go` are always parsed regardless of
-  whether their filename suffix matches the host. Only in-source
-  `//go:build` / `// +build` lines are evaluated.
 
 - **No cgo support**: The `import "C"` pseudo-import is filtered out.
 

--- a/packages/gonx/src/graph/static-analysis/build-constraints.spec.ts
+++ b/packages/gonx/src/graph/static-analysis/build-constraints.spec.ts
@@ -1,17 +1,60 @@
+jest.mock('@nx/devkit', () => ({ logger: { warn: jest.fn() } }));
+jest.mock('os', () => ({
+  ...jest.requireActual('os'),
+  platform: jest.fn(() => 'linux'),
+  arch: jest.fn(() => 'x64'),
+}));
+
+import { logger } from '@nx/devkit';
+import { platform, arch } from 'os';
 import {
   BuildContext,
   getDefaultBuildContext,
   shouldIncludeFile,
+  shouldIncludeFilename,
 } from './build-constraints';
 
-const LINUX_AMD64: BuildContext = { goos: 'linux', goarch: 'amd64' };
-const DARWIN_ARM64: BuildContext = { goos: 'darwin', goarch: 'arm64' };
-const WINDOWS_AMD64: BuildContext = { goos: 'windows', goarch: 'amd64' };
+const mockedWarn = logger.warn as jest.MockedFunction<typeof logger.warn>;
+const mockedPlatform = platform as jest.MockedFunction<typeof platform>;
+const mockedArch = arch as jest.MockedFunction<typeof arch>;
+
+const EMPTY_TAGS: ReadonlySet<string> = new Set();
+const LINUX_AMD64: BuildContext = {
+  goos: 'linux',
+  goarch: 'amd64',
+  tags: EMPTY_TAGS,
+};
+const DARWIN_ARM64: BuildContext = {
+  goos: 'darwin',
+  goarch: 'arm64',
+  tags: EMPTY_TAGS,
+};
+const WINDOWS_AMD64: BuildContext = {
+  goos: 'windows',
+  goarch: 'amd64',
+  tags: EMPTY_TAGS,
+};
+const LINUX_ARM64: BuildContext = {
+  goos: 'linux',
+  goarch: 'arm64',
+  tags: EMPTY_TAGS,
+};
+const DARWIN_AMD64: BuildContext = {
+  goos: 'darwin',
+  goarch: 'amd64',
+  tags: EMPTY_TAGS,
+};
 
 /** Wrap a constraint comment in a minimal Go file. */
 function withConstraint(comment: string): string {
   return `${comment}\n\npackage foo\n\nimport "fmt"\n`;
 }
+
+beforeEach(() => {
+  mockedWarn.mockClear();
+  mockedPlatform.mockReturnValue('linux');
+  mockedArch.mockReturnValue('x64');
+});
 
 describe('shouldIncludeFile', () => {
   it('includes a file without any constraint', () => {
@@ -39,10 +82,18 @@ describe('shouldIncludeFile', () => {
       const content = withConstraint('//go:build linux && amd64');
       expect(shouldIncludeFile(content, LINUX_AMD64)).toBe(true);
       expect(
-        shouldIncludeFile(content, { goos: 'linux', goarch: 'arm64' })
+        shouldIncludeFile(content, {
+          goos: 'linux',
+          goarch: 'arm64',
+          tags: EMPTY_TAGS,
+        })
       ).toBe(false);
       expect(
-        shouldIncludeFile(content, { goos: 'darwin', goarch: 'amd64' })
+        shouldIncludeFile(content, {
+          goos: 'darwin',
+          goarch: 'amd64',
+          tags: EMPTY_TAGS,
+        })
       ).toBe(false);
     });
 
@@ -59,7 +110,11 @@ describe('shouldIncludeFile', () => {
       expect(shouldIncludeFile(content, LINUX_AMD64)).toBe(true);
       expect(shouldIncludeFile(content, DARWIN_ARM64)).toBe(false);
       expect(
-        shouldIncludeFile(content, { goos: 'darwin', goarch: 'amd64' })
+        shouldIncludeFile(content, {
+          goos: 'darwin',
+          goarch: 'amd64',
+          tags: EMPTY_TAGS,
+        })
       ).toBe(true);
       expect(shouldIncludeFile(content, WINDOWS_AMD64)).toBe(false);
     });
@@ -89,11 +144,36 @@ describe('shouldIncludeFile', () => {
     });
 
     it('takes the first //go:build line when multiple are present', () => {
-      // Per the Go spec, the first build constraint in the file wins.
-      const content =
-        '//go:build linux\n//go:build windows\n\npackage foo\n\nimport "fmt"\n';
+      // The Go spec actually rejects files with more than one //go:build
+      // line — `gofmt` and `go vet` flag duplicates as an error. We
+      // tolerate duplicates and pick the first as a leniency choice;
+      // this test pins that policy.
+      const content = withConstraint('//go:build linux\n//go:build windows');
       expect(shouldIncludeFile(content, LINUX_AMD64)).toBe(true);
       expect(shouldIncludeFile(content, WINDOWS_AMD64)).toBe(false);
+    });
+
+    it('respects operator precedence with && binding tighter than ||', () => {
+      // `linux && arm64 || darwin && amd64` must parse as
+      // `(linux && arm64) || (darwin && amd64)`. If a future change
+      // swapped to OR-binds-tighter, LINUX_ARM64 and DARWIN_AMD64 below
+      // would both flip from true to false.
+      const content = withConstraint(
+        '//go:build linux && arm64 || darwin && amd64'
+      );
+      expect(shouldIncludeFile(content, LINUX_ARM64)).toBe(true);
+      expect(shouldIncludeFile(content, DARWIN_AMD64)).toBe(true);
+      expect(shouldIncludeFile(content, LINUX_AMD64)).toBe(false);
+      expect(shouldIncludeFile(content, WINDOWS_AMD64)).toBe(false);
+    });
+
+    it('treats a lone `!` operand as include, not exclude', () => {
+      // `!` with no operand previously evaluated as `!true → false`,
+      // silently *excluding* the file. The over-include policy demands
+      // include on every malformed shape.
+      const content = withConstraint('//go:build !');
+      expect(shouldIncludeFile(content, LINUX_AMD64)).toBe(true);
+      expect(shouldIncludeFile(content, WINDOWS_AMD64)).toBe(true);
     });
   });
 
@@ -117,7 +197,11 @@ describe('shouldIncludeFile', () => {
       expect(shouldIncludeFile(content, LINUX_AMD64)).toBe(true);
       expect(shouldIncludeFile(content, DARWIN_ARM64)).toBe(true);
       expect(
-        shouldIncludeFile(content, { goos: 'linux', goarch: 'arm64' })
+        shouldIncludeFile(content, {
+          goos: 'linux',
+          goarch: 'arm64',
+          tags: EMPTY_TAGS,
+        })
       ).toBe(false);
       expect(shouldIncludeFile(content, WINDOWS_AMD64)).toBe(false);
     });
@@ -131,14 +215,21 @@ describe('shouldIncludeFile', () => {
     });
 
     it('ANDs multiple // +build lines together', () => {
-      const content =
-        '// +build linux\n// +build amd64\n\npackage foo\n\nimport "fmt"\n';
+      const content = withConstraint('// +build linux\n// +build amd64');
       expect(shouldIncludeFile(content, LINUX_AMD64)).toBe(true);
       expect(
-        shouldIncludeFile(content, { goos: 'linux', goarch: 'arm64' })
+        shouldIncludeFile(content, {
+          goos: 'linux',
+          goarch: 'arm64',
+          tags: EMPTY_TAGS,
+        })
       ).toBe(false);
       expect(
-        shouldIncludeFile(content, { goos: 'darwin', goarch: 'amd64' })
+        shouldIncludeFile(content, {
+          goos: 'darwin',
+          goarch: 'amd64',
+          tags: EMPTY_TAGS,
+        })
       ).toBe(false);
     });
   });
@@ -147,8 +238,7 @@ describe('shouldIncludeFile', () => {
     it('uses //go:build when both forms are present', () => {
       // Modern says linux (true on linux); legacy contradicts (windows-only).
       // Modern wins.
-      const content =
-        '//go:build linux\n// +build windows\n\npackage foo\n\nimport "fmt"\n';
+      const content = withConstraint('//go:build linux\n// +build windows');
       expect(shouldIncludeFile(content, LINUX_AMD64)).toBe(true);
       expect(shouldIncludeFile(content, WINDOWS_AMD64)).toBe(false);
     });
@@ -177,12 +267,203 @@ describe('shouldIncludeFile', () => {
   });
 });
 
+describe('directive recognition', () => {
+  it('ignores `//go:buildfoo` (no whitespace after the directive token)', () => {
+    // Loose `startsWith` would accept this as a `//go:build` directive
+    // and evaluate "foo darwin" → the file would silently include or
+    // exclude on a typo. Tightened matching rejects it as a comment.
+    const content = '//go:buildfoo darwin\n\npackage foo\n\nimport "fmt"\n';
+    expect(shouldIncludeFile(content, LINUX_AMD64)).toBe(true);
+    expect(shouldIncludeFile(content, WINDOWS_AMD64)).toBe(true);
+  });
+
+  it('ignores `// +builder` (no whitespace after the directive token)', () => {
+    const content = '// +builder x\n\npackage foo\n\nimport "fmt"\n';
+    expect(shouldIncludeFile(content, LINUX_AMD64)).toBe(true);
+    expect(shouldIncludeFile(content, WINDOWS_AMD64)).toBe(true);
+  });
+
+  it('does not treat constraint-shaped text in a block comment as a directive', () => {
+    // The Go spec recognizes constraints only in `//`-style line comments,
+    // never inside `/* ... */` blocks. The scanner honors this because
+    // the trimmed line starts with `/*`, not `//go:build`. This test pins
+    // the invariant against future scanner refactors.
+    const content = '/* //go:build windows */\n\npackage foo\n\nimport "fmt"\n';
+    expect(shouldIncludeFile(content, LINUX_AMD64)).toBe(true);
+    expect(shouldIncludeFile(content, WINDOWS_AMD64)).toBe(true);
+  });
+});
+
+describe('malformed-expression warnings', () => {
+  it('warns when trailing tokens force an over-include', () => {
+    // Typo: spaces instead of `&&`. Without the warning the user has no
+    // way to tell their intended constraint was thrown away and the
+    // file silently includes on every platform.
+    const content = withConstraint('//go:build linux foo bar');
+    expect(shouldIncludeFile(content, WINDOWS_AMD64, 'path/to/a.go')).toBe(
+      true
+    );
+    expect(mockedWarn).toHaveBeenCalledTimes(1);
+    expect(mockedWarn).toHaveBeenCalledWith(
+      expect.stringContaining('trailing tokens')
+    );
+    expect(mockedWarn.mock.calls[0][0]).toContain('path/to/a.go');
+  });
+
+  it('warns on an empty //go:build constraint', () => {
+    const content = withConstraint('//go:build');
+    expect(shouldIncludeFile(content, LINUX_AMD64, 'a.go')).toBe(true);
+    expect(mockedWarn).toHaveBeenCalledWith(
+      expect.stringContaining('Empty //go:build')
+    );
+  });
+
+  it('warns when the tokenizer skips unrecognized characters', () => {
+    // A bare hyphen isn't in the alphanumeric tag set; the tokenizer
+    // silently dropped it before this fix.
+    const content = withConstraint('//go:build my-tag');
+    expect(shouldIncludeFile(content, LINUX_AMD64, 'a.go')).toBe(true);
+    expect(mockedWarn).toHaveBeenCalledWith(
+      expect.stringContaining('unrecognized characters')
+    );
+  });
+
+  it('stays silent when no sourceLabel is provided', () => {
+    // Unit tests that exercise the malformed paths don't want the noise.
+    const content = withConstraint('//go:build linux foo bar');
+    expect(shouldIncludeFile(content, WINDOWS_AMD64)).toBe(true);
+    expect(mockedWarn).not.toHaveBeenCalled();
+  });
+});
+
+describe('shouldIncludeFilename', () => {
+  it('includes a file with no recognized suffix', () => {
+    expect(shouldIncludeFilename('foo.go', LINUX_AMD64)).toBe(true);
+    expect(shouldIncludeFilename('foo.go', WINDOWS_AMD64)).toBe(true);
+    expect(shouldIncludeFilename('nethelper.go', LINUX_AMD64)).toBe(true);
+  });
+
+  it('returns true for non-Go filenames (caller passed wrong file)', () => {
+    expect(shouldIncludeFilename('foo.txt', LINUX_AMD64)).toBe(true);
+  });
+
+  it('gates on GOOS for `name_<GOOS>.go`', () => {
+    expect(shouldIncludeFilename('signal_linux.go', LINUX_AMD64)).toBe(true);
+    expect(shouldIncludeFilename('signal_linux.go', DARWIN_ARM64)).toBe(false);
+    expect(shouldIncludeFilename('signal_linux.go', WINDOWS_AMD64)).toBe(false);
+  });
+
+  it('gates on GOARCH for `name_<GOARCH>.go`', () => {
+    expect(shouldIncludeFilename('sha1block_amd64.go', LINUX_AMD64)).toBe(true);
+    expect(shouldIncludeFilename('sha1block_amd64.go', DARWIN_ARM64)).toBe(
+      false
+    );
+  });
+
+  it('gates on both for `name_<GOOS>_<GOARCH>.go`', () => {
+    expect(
+      shouldIncludeFilename('zsyscall_darwin_arm64.go', DARWIN_ARM64)
+    ).toBe(true);
+    expect(
+      shouldIncludeFilename('zsyscall_darwin_arm64.go', DARWIN_AMD64)
+    ).toBe(false);
+    expect(shouldIncludeFilename('zsyscall_darwin_arm64.go', LINUX_ARM64)).toBe(
+      false
+    );
+  });
+
+  it('handles `_test.go` suffix combined with GOOS', () => {
+    expect(shouldIncludeFilename('foo_linux_test.go', LINUX_AMD64)).toBe(true);
+    expect(shouldIncludeFilename('foo_linux_test.go', WINDOWS_AMD64)).toBe(
+      false
+    );
+  });
+
+  it('handles `_test.go` suffix combined with GOOS+GOARCH', () => {
+    expect(
+      shouldIncludeFilename('foo_darwin_arm64_test.go', DARWIN_ARM64)
+    ).toBe(true);
+    expect(shouldIncludeFilename('foo_darwin_arm64_test.go', LINUX_AMD64)).toBe(
+      false
+    );
+  });
+
+  it('treats reverse-ordered <GOARCH>_<GOOS> as a single-token GOOS gate', () => {
+    // Per the Go spec the pair check requires order GOOS-then-GOARCH.
+    // `foo_amd64_linux.go` falls through to the single-token check on
+    // the trailing `linux` (a known GOOS) → gates on linux only, ignores
+    // the `amd64` entirely.
+    expect(shouldIncludeFilename('foo_amd64_linux.go', LINUX_AMD64)).toBe(true);
+    expect(shouldIncludeFilename('foo_amd64_linux.go', LINUX_ARM64)).toBe(true);
+    expect(shouldIncludeFilename('foo_amd64_linux.go', DARWIN_AMD64)).toBe(
+      false
+    );
+  });
+
+  it('does not treat `unix` as a filename suffix', () => {
+    // `unix` is a build-tag pseudo-name, NOT a known GOOS. A file named
+    // `foo_unix.go` is unconstrained by filename (the constraint would
+    // need to be a `//go:build unix` directive in the source).
+    expect(shouldIncludeFilename('foo_unix.go', LINUX_AMD64)).toBe(true);
+    expect(shouldIncludeFilename('foo_unix.go', WINDOWS_AMD64)).toBe(true);
+  });
+
+  it('strips directory components from the path', () => {
+    expect(shouldIncludeFilename('/abs/pkg/signal_linux.go', LINUX_AMD64)).toBe(
+      true
+    );
+    expect(
+      shouldIncludeFilename('/abs/pkg/signal_linux.go', WINDOWS_AMD64)
+    ).toBe(false);
+    // Windows-style backslash separator
+    expect(
+      shouldIncludeFilename('C:\\\\pkg\\\\signal_linux.go', WINDOWS_AMD64)
+    ).toBe(false);
+  });
+
+  it('ignores tokens before the trailing platform suffix', () => {
+    // `helper` isn't a platform name; only `linux` is checked.
+    expect(shouldIncludeFilename('foo_helper_linux.go', LINUX_AMD64)).toBe(
+      true
+    );
+    expect(shouldIncludeFilename('foo_helper_linux.go', DARWIN_ARM64)).toBe(
+      false
+    );
+  });
+});
+
 describe('getDefaultBuildContext', () => {
-  it('returns the current platform as a Go-shaped context', () => {
+  it('maps win32 to windows and x64 to amd64', () => {
+    mockedPlatform.mockReturnValue('win32');
+    mockedArch.mockReturnValue('x64');
     const ctx = getDefaultBuildContext();
-    expect(typeof ctx.goos).toBe('string');
-    expect(typeof ctx.goarch).toBe('string');
-    expect(ctx.goos.length).toBeGreaterThan(0);
-    expect(ctx.goarch.length).toBeGreaterThan(0);
+    expect(ctx.goos).toBe('windows');
+    expect(ctx.goarch).toBe('amd64');
+  });
+
+  it('maps sunos to solaris', () => {
+    mockedPlatform.mockReturnValue('sunos');
+    mockedArch.mockReturnValue('x64');
+    expect(getDefaultBuildContext().goos).toBe('solaris');
+  });
+
+  it('maps darwin/arm64 to themselves', () => {
+    mockedPlatform.mockReturnValue('darwin');
+    mockedArch.mockReturnValue('arm64');
+    const ctx = getDefaultBuildContext();
+    expect(ctx.goos).toBe('darwin');
+    expect(ctx.goarch).toBe('arm64');
+  });
+
+  it('initializes an empty tags set by default', () => {
+    expect(getDefaultBuildContext().tags.size).toBe(0);
+  });
+
+  it('passes unknown Node platforms through unchanged', () => {
+    // Best-effort fallback: a niche Node platform (e.g. cygwin) is
+    // returned as-is. Documented behavior.
+    mockedPlatform.mockReturnValue('cygwin' as NodeJS.Platform);
+    mockedArch.mockReturnValue('x64');
+    expect(getDefaultBuildContext().goos).toBe('cygwin');
   });
 });

--- a/packages/gonx/src/graph/static-analysis/build-constraints.spec.ts
+++ b/packages/gonx/src/graph/static-analysis/build-constraints.spec.ts
@@ -1,0 +1,188 @@
+import {
+  BuildContext,
+  getDefaultBuildContext,
+  shouldIncludeFile,
+} from './build-constraints';
+
+const LINUX_AMD64: BuildContext = { goos: 'linux', goarch: 'amd64' };
+const DARWIN_ARM64: BuildContext = { goos: 'darwin', goarch: 'arm64' };
+const WINDOWS_AMD64: BuildContext = { goos: 'windows', goarch: 'amd64' };
+
+/** Wrap a constraint comment in a minimal Go file. */
+function withConstraint(comment: string): string {
+  return `${comment}\n\npackage foo\n\nimport "fmt"\n`;
+}
+
+describe('shouldIncludeFile', () => {
+  it('includes a file without any constraint', () => {
+    const content = 'package foo\n\nimport "fmt"\n';
+    expect(shouldIncludeFile(content, LINUX_AMD64)).toBe(true);
+    expect(shouldIncludeFile(content, WINDOWS_AMD64)).toBe(true);
+  });
+
+  describe('//go:build', () => {
+    it('matches a single GOOS tag (acceptance: linux on linux)', () => {
+      const content = withConstraint('//go:build linux');
+      expect(shouldIncludeFile(content, LINUX_AMD64)).toBe(true);
+      expect(shouldIncludeFile(content, DARWIN_ARM64)).toBe(false);
+      expect(shouldIncludeFile(content, WINDOWS_AMD64)).toBe(false);
+    });
+
+    it('handles negation (acceptance: !windows)', () => {
+      const content = withConstraint('//go:build !windows');
+      expect(shouldIncludeFile(content, LINUX_AMD64)).toBe(true);
+      expect(shouldIncludeFile(content, DARWIN_ARM64)).toBe(true);
+      expect(shouldIncludeFile(content, WINDOWS_AMD64)).toBe(false);
+    });
+
+    it('handles AND', () => {
+      const content = withConstraint('//go:build linux && amd64');
+      expect(shouldIncludeFile(content, LINUX_AMD64)).toBe(true);
+      expect(
+        shouldIncludeFile(content, { goos: 'linux', goarch: 'arm64' })
+      ).toBe(false);
+      expect(
+        shouldIncludeFile(content, { goos: 'darwin', goarch: 'amd64' })
+      ).toBe(false);
+    });
+
+    it('handles OR', () => {
+      const content = withConstraint('//go:build linux || darwin');
+      expect(shouldIncludeFile(content, LINUX_AMD64)).toBe(true);
+      expect(shouldIncludeFile(content, DARWIN_ARM64)).toBe(true);
+      expect(shouldIncludeFile(content, WINDOWS_AMD64)).toBe(false);
+    });
+
+    it('respects parentheses for precedence', () => {
+      // `(linux || darwin) && amd64`: amd64 required on either unix host.
+      const content = withConstraint('//go:build (linux || darwin) && amd64');
+      expect(shouldIncludeFile(content, LINUX_AMD64)).toBe(true);
+      expect(shouldIncludeFile(content, DARWIN_ARM64)).toBe(false);
+      expect(
+        shouldIncludeFile(content, { goos: 'darwin', goarch: 'amd64' })
+      ).toBe(true);
+      expect(shouldIncludeFile(content, WINDOWS_AMD64)).toBe(false);
+    });
+
+    it('matches the `unix` pseudo-tag for unix-like OSes', () => {
+      const content = withConstraint('//go:build unix');
+      expect(shouldIncludeFile(content, LINUX_AMD64)).toBe(true);
+      expect(shouldIncludeFile(content, DARWIN_ARM64)).toBe(true);
+      expect(shouldIncludeFile(content, WINDOWS_AMD64)).toBe(false);
+    });
+
+    it('treats `go1.X` tags as always satisfied', () => {
+      const content = withConstraint('//go:build go1.22');
+      expect(shouldIncludeFile(content, LINUX_AMD64)).toBe(true);
+      expect(shouldIncludeFile(content, WINDOWS_AMD64)).toBe(true);
+    });
+
+    it('treats unknown identifiers as user tags (false by default)', () => {
+      const content = withConstraint('//go:build integration');
+      expect(shouldIncludeFile(content, LINUX_AMD64)).toBe(false);
+      expect(
+        shouldIncludeFile(content, {
+          ...LINUX_AMD64,
+          tags: new Set(['integration']),
+        })
+      ).toBe(true);
+    });
+
+    it('takes the first //go:build line when multiple are present', () => {
+      // Per the Go spec, the first build constraint in the file wins.
+      const content =
+        '//go:build linux\n//go:build windows\n\npackage foo\n\nimport "fmt"\n';
+      expect(shouldIncludeFile(content, LINUX_AMD64)).toBe(true);
+      expect(shouldIncludeFile(content, WINDOWS_AMD64)).toBe(false);
+    });
+  });
+
+  describe('// +build (legacy)', () => {
+    it('matches a single tag', () => {
+      const content = withConstraint('// +build linux');
+      expect(shouldIncludeFile(content, LINUX_AMD64)).toBe(true);
+      expect(shouldIncludeFile(content, WINDOWS_AMD64)).toBe(false);
+    });
+
+    it('treats space-separated terms as OR', () => {
+      const content = withConstraint('// +build linux darwin');
+      expect(shouldIncludeFile(content, LINUX_AMD64)).toBe(true);
+      expect(shouldIncludeFile(content, DARWIN_ARM64)).toBe(true);
+      expect(shouldIncludeFile(content, WINDOWS_AMD64)).toBe(false);
+    });
+
+    it('treats comma-separated terms within an option as AND', () => {
+      // `linux,amd64 darwin,arm64` → (linux AND amd64) OR (darwin AND arm64)
+      const content = withConstraint('// +build linux,amd64 darwin,arm64');
+      expect(shouldIncludeFile(content, LINUX_AMD64)).toBe(true);
+      expect(shouldIncludeFile(content, DARWIN_ARM64)).toBe(true);
+      expect(
+        shouldIncludeFile(content, { goos: 'linux', goarch: 'arm64' })
+      ).toBe(false);
+      expect(shouldIncludeFile(content, WINDOWS_AMD64)).toBe(false);
+    });
+
+    it('handles `!` negation per term', () => {
+      // `darwin,!cgo` → darwin AND NOT cgo. cgo is always false in our model,
+      // so this matches on darwin.
+      const content = withConstraint('// +build darwin,!cgo');
+      expect(shouldIncludeFile(content, DARWIN_ARM64)).toBe(true);
+      expect(shouldIncludeFile(content, LINUX_AMD64)).toBe(false);
+    });
+
+    it('ANDs multiple // +build lines together', () => {
+      const content =
+        '// +build linux\n// +build amd64\n\npackage foo\n\nimport "fmt"\n';
+      expect(shouldIncludeFile(content, LINUX_AMD64)).toBe(true);
+      expect(
+        shouldIncludeFile(content, { goos: 'linux', goarch: 'arm64' })
+      ).toBe(false);
+      expect(
+        shouldIncludeFile(content, { goos: 'darwin', goarch: 'amd64' })
+      ).toBe(false);
+    });
+  });
+
+  describe('precedence between forms', () => {
+    it('uses //go:build when both forms are present', () => {
+      // Modern says linux (true on linux); legacy contradicts (windows-only).
+      // Modern wins.
+      const content =
+        '//go:build linux\n// +build windows\n\npackage foo\n\nimport "fmt"\n';
+      expect(shouldIncludeFile(content, LINUX_AMD64)).toBe(true);
+      expect(shouldIncludeFile(content, WINDOWS_AMD64)).toBe(false);
+    });
+  });
+
+  describe('robustness', () => {
+    it('falls back to include on a malformed expression', () => {
+      // Unbalanced paren: better to over-include than crash graph build.
+      const content = withConstraint('//go:build (linux');
+      expect(shouldIncludeFile(content, LINUX_AMD64)).toBe(true);
+    });
+
+    it('handles CRLF line endings', () => {
+      const content =
+        '//go:build linux\r\n\r\npackage foo\r\n\r\nimport "fmt"\r\n';
+      expect(shouldIncludeFile(content, LINUX_AMD64)).toBe(true);
+      expect(shouldIncludeFile(content, WINDOWS_AMD64)).toBe(false);
+    });
+
+    it('ignores constraint-shaped text after the package clause', () => {
+      // A `//go:build` line appearing AFTER `package` is not a build
+      // constraint per the spec; it must be in the header.
+      const content = 'package foo\n\n//go:build windows\n\nimport "fmt"\n';
+      expect(shouldIncludeFile(content, LINUX_AMD64)).toBe(true);
+    });
+  });
+});
+
+describe('getDefaultBuildContext', () => {
+  it('returns the current platform as a Go-shaped context', () => {
+    const ctx = getDefaultBuildContext();
+    expect(typeof ctx.goos).toBe('string');
+    expect(typeof ctx.goarch).toBe('string');
+    expect(ctx.goos.length).toBeGreaterThan(0);
+    expect(ctx.goarch.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/gonx/src/graph/static-analysis/build-constraints.ts
+++ b/packages/gonx/src/graph/static-analysis/build-constraints.ts
@@ -1,0 +1,322 @@
+/**
+ * Go build-constraint evaluation for static dependency analysis.
+ *
+ * Supports both forms:
+ *  - Modern `//go:build` (boolean expression with `&&`, `||`, `!`, parens)
+ *  - Legacy `// +build` (OR-of-AND term lists; multiple lines AND'd)
+ *
+ * When both are present (a transitional state Go's toolchain leaves
+ * during `go fmt` runs), `//go:build` wins per the spec.
+ *
+ * Known limitations (tracked separately, not in scope here):
+ *  - Filename-based suffixes (e.g. `foo_linux.go`) are NOT honored — only
+ *    in-source constraint comments are.
+ *  - `go1.X` version tags are treated as always-true: we have no compiler
+ *    handy to consult, and over-including is safer than under-including
+ *    for graph computation.
+ *  - The pseudo-tag `cgo` is treated as false (static analysis never runs
+ *    cgo).
+ */
+
+import { platform, arch } from 'os';
+
+export interface BuildContext {
+  readonly goos: string;
+  readonly goarch: string;
+  /** User-supplied tags (e.g. `integration`, `debug`). Empty by default. */
+  readonly tags?: ReadonlySet<string>;
+}
+
+/** Unix-like GOOS values per Go's `runtime` package classification. */
+const UNIX_OSES: ReadonlySet<string> = new Set([
+  'aix',
+  'android',
+  'darwin',
+  'dragonfly',
+  'freebsd',
+  'hurd',
+  'illumos',
+  'ios',
+  'linux',
+  'netbsd',
+  'openbsd',
+  'solaris',
+]);
+
+function nodePlatformToGoos(p: NodeJS.Platform): string {
+  switch (p) {
+    case 'darwin':
+      return 'darwin';
+    case 'linux':
+      return 'linux';
+    case 'win32':
+      return 'windows';
+    case 'freebsd':
+      return 'freebsd';
+    case 'openbsd':
+      return 'openbsd';
+    case 'sunos':
+      return 'solaris';
+    case 'aix':
+      return 'aix';
+    default:
+      // Best-effort: pass through unknown platforms (e.g. android, cygwin).
+      return p;
+  }
+}
+
+function nodeArchToGoarch(a: string): string {
+  switch (a) {
+    case 'x64':
+      return 'amd64';
+    case 'ia32':
+      return '386';
+    case 'arm64':
+      return 'arm64';
+    case 'arm':
+      return 'arm';
+    case 'ppc64':
+      return 'ppc64';
+    case 's390x':
+      return 's390x';
+    case 'mips':
+      return 'mips';
+    case 'mipsel':
+      return 'mipsle';
+    case 'riscv64':
+      return 'riscv64';
+    case 'loong64':
+      return 'loong64';
+    default:
+      return a;
+  }
+}
+
+/**
+ * Derive a default `BuildContext` from the current Node process.
+ * The result is process-stable — safe to memoize at module level.
+ */
+export function getDefaultBuildContext(): BuildContext {
+  return {
+    goos: nodePlatformToGoos(platform()),
+    goarch: nodeArchToGoarch(arch()),
+  };
+}
+
+/**
+ * Decide whether a Go source file should be considered for import
+ * extraction given its content and a build context. Returns `true` when
+ * no recognized build constraint is present.
+ */
+export function shouldIncludeFile(content: string, ctx: BuildContext): boolean {
+  const { goBuild, plusBuild } = readHeaderConstraints(content);
+  if (goBuild !== null) {
+    return evaluateGoBuild(goBuild, ctx);
+  }
+  if (plusBuild.length > 0) {
+    // Multiple `// +build` lines are AND'd per the legacy spec.
+    return plusBuild.every((line) => evaluateLegacyLine(line, ctx));
+  }
+  return true;
+}
+
+/**
+ * Scan the file header up to the `package` clause and collect constraint
+ * comments. The Go spec requires constraints to precede `package` (with
+ * a blank line between); we don't enforce the blank-line rule strictly —
+ * we just stop at the first `package` line.
+ */
+function readHeaderConstraints(content: string): {
+  goBuild: string | null;
+  plusBuild: string[];
+} {
+  let goBuild: string | null = null;
+  const plusBuild: string[] = [];
+
+  for (const raw of content.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (line.startsWith('package ') || line === 'package') {
+      break;
+    }
+    if (line.startsWith('//go:build')) {
+      // Per spec: the first build constraint in the file wins.
+      if (goBuild === null) {
+        goBuild = line.slice('//go:build'.length).trim();
+      }
+    } else if (line.startsWith('// +build')) {
+      plusBuild.push(line);
+    }
+  }
+
+  return { goBuild, plusBuild };
+}
+
+// --- //go:build expression evaluator ---------------------------------------
+
+type Token =
+  | { kind: 'ident'; value: string }
+  | { kind: '&&' | '||' | '!' | '(' | ')' };
+
+interface ParseState {
+  tokens: Token[];
+  pos: number;
+}
+
+function evaluateGoBuild(expr: string, ctx: BuildContext): boolean {
+  const tokens = tokenize(expr);
+  if (tokens.length === 0) {
+    // Empty `//go:build` is invalid per spec; fall back to include rather
+    // than excluding the file on a malformed constraint.
+    return true;
+  }
+  const state: ParseState = { tokens, pos: 0 };
+  const result = parseOr(state, ctx);
+  // Extra tokens or unbalanced parens → treat as include (safe fallback).
+  if (state.pos < state.tokens.length) return true;
+  return result;
+}
+
+function tokenize(expr: string): Token[] {
+  const tokens: Token[] = [];
+  let i = 0;
+  while (i < expr.length) {
+    const c = expr[i];
+    if (c === ' ' || c === '\t') {
+      i++;
+      continue;
+    }
+    if (c === '(') {
+      tokens.push({ kind: '(' });
+      i++;
+      continue;
+    }
+    if (c === ')') {
+      tokens.push({ kind: ')' });
+      i++;
+      continue;
+    }
+    if (c === '!') {
+      tokens.push({ kind: '!' });
+      i++;
+      continue;
+    }
+    if (c === '&' && expr[i + 1] === '&') {
+      tokens.push({ kind: '&&' });
+      i += 2;
+      continue;
+    }
+    if (c === '|' && expr[i + 1] === '|') {
+      tokens.push({ kind: '||' });
+      i += 2;
+      continue;
+    }
+    if (/[A-Za-z0-9_.]/.test(c)) {
+      let j = i;
+      while (j < expr.length && /[A-Za-z0-9_.]/.test(expr[j])) j++;
+      tokens.push({ kind: 'ident', value: expr.slice(i, j) });
+      i = j;
+      continue;
+    }
+    // Unknown character: skip rather than throw. A build constraint is
+    // never worth failing graph construction over.
+    i++;
+  }
+  return tokens;
+}
+
+// Grammar:
+//   or-expr  = and-expr ( '||' and-expr )*
+//   and-expr = unary    ( '&&' unary    )*
+//   unary    = '!' unary | primary
+//   primary  = ident | '(' or-expr ')'
+
+function parseOr(s: ParseState, ctx: BuildContext): boolean {
+  let left = parseAnd(s, ctx);
+  while (peek(s)?.kind === '||') {
+    s.pos++;
+    const right = parseAnd(s, ctx);
+    left = left || right;
+  }
+  return left;
+}
+
+function parseAnd(s: ParseState, ctx: BuildContext): boolean {
+  let left = parseUnary(s, ctx);
+  while (peek(s)?.kind === '&&') {
+    s.pos++;
+    const right = parseUnary(s, ctx);
+    left = left && right;
+  }
+  return left;
+}
+
+function parseUnary(s: ParseState, ctx: BuildContext): boolean {
+  if (peek(s)?.kind === '!') {
+    s.pos++;
+    return !parseUnary(s, ctx);
+  }
+  return parsePrimary(s, ctx);
+}
+
+function parsePrimary(s: ParseState, ctx: BuildContext): boolean {
+  const tok = peek(s);
+  if (!tok) return true; // safe fallback at EOF
+  if (tok.kind === '(') {
+    s.pos++;
+    const inner = parseOr(s, ctx);
+    if (peek(s)?.kind === ')') s.pos++;
+    return inner;
+  }
+  if (tok.kind === 'ident') {
+    s.pos++;
+    return matchTag(tok.value, ctx);
+  }
+  // Unexpected operator-in-primary position: include rather than crash.
+  return true;
+}
+
+function peek(s: ParseState): Token | undefined {
+  return s.tokens[s.pos];
+}
+
+// --- // +build line evaluator ---------------------------------------------
+
+function evaluateLegacyLine(line: string, ctx: BuildContext): boolean {
+  const stripped = line.replace(/^\/\/\s*\+build\s*/, '').trim();
+  if (!stripped) return true;
+  // Space-separated options are OR'd.
+  const options = stripped.split(/\s+/);
+  return options.some((option) => evaluateLegacyOption(option, ctx));
+}
+
+function evaluateLegacyOption(option: string, ctx: BuildContext): boolean {
+  // Comma-separated terms within an option are AND'd. Each term may be
+  // prefixed with `!` to negate.
+  const terms = option.split(',');
+  return terms.every((term) => {
+    let id = term;
+    let negate = false;
+    if (id.startsWith('!')) {
+      negate = true;
+      id = id.slice(1);
+    }
+    const match = matchTag(id, ctx);
+    return negate ? !match : match;
+  });
+}
+
+// --- tag matching ---------------------------------------------------------
+
+function matchTag(tag: string, ctx: BuildContext): boolean {
+  if (!tag) return false;
+  if (tag === ctx.goos) return true;
+  if (tag === ctx.goarch) return true;
+  if (tag === 'unix' && UNIX_OSES.has(ctx.goos)) return true;
+  // Go-version tags: assume the user's compiler satisfies them. Over-
+  // including is safer than under-including for graph purposes.
+  if (/^go1\.\d+$/.test(tag)) return true;
+  // We never invoke cgo from static analysis.
+  if (tag === 'cgo') return false;
+  if (ctx.tags?.has(tag)) return true;
+  return false;
+}

--- a/packages/gonx/src/graph/static-analysis/build-constraints.ts
+++ b/packages/gonx/src/graph/static-analysis/build-constraints.ts
@@ -5,30 +5,71 @@
  *  - Modern `//go:build` (boolean expression with `&&`, `||`, `!`, parens)
  *  - Legacy `// +build` (OR-of-AND term lists; multiple lines AND'd)
  *
- * When both are present (a transitional state Go's toolchain leaves
- * during `go fmt` runs), `//go:build` wins per the spec.
+ * When both are present (`gofmt` emits both for files that must compile
+ * under pre-1.17 Go), `//go:build` wins per the spec.
  *
- * Known limitations (tracked separately, not in scope here):
- *  - Filename-based suffixes (e.g. `foo_linux.go`) are NOT honored — only
- *    in-source constraint comments are.
+ * Honored alongside the in-source forms: Go's filename-suffix conventions
+ * (`name_<GOOS>.go`, `name_<GOARCH>.go`, `name_<GOOS>_<GOARCH>.go`, with an
+ * optional trailing `_test`). See `shouldIncludeFilename`.
+ *
+ * Known limitations:
  *  - `go1.X` version tags are treated as always-true: we have no compiler
  *    handy to consult, and over-including is safer than under-including
- *    for graph computation.
+ *    for graph computation. Tracked in #108 (lift policy onto context).
  *  - The pseudo-tag `cgo` is treated as false (static analysis never runs
- *    cgo).
+ *    cgo). Same tracking issue (#108).
  */
 
+import { logger } from '@nx/devkit';
 import { platform, arch } from 'os';
 
-export interface BuildContext {
-  readonly goos: string;
-  readonly goarch: string;
-  /** User-supplied tags (e.g. `integration`, `debug`). Empty by default. */
-  readonly tags?: ReadonlySet<string>;
-}
+// === Go GOOS values ============================================================
+//
+// One tuple is the source of truth. The internal `KnownGoOS` literal union and
+// the runtime `KNOWN_GOOSES` set are both derived from it, so adding a platform
+// is a single-line change. The exported `GoOS` adds a `(string & {})` escape
+// hatch so unknown Node platforms still pass through `nodePlatformToGoos`
+// without losing autocomplete on the canonical set.
 
-/** Unix-like GOOS values per Go's `runtime` package classification. */
-const UNIX_OSES: ReadonlySet<string> = new Set([
+/** Canonical Go `GOOS` values per `internal/syslist.KnownOS`. */
+const KNOWN_GOOSES_LIST = [
+  'aix',
+  'android',
+  'darwin',
+  'dragonfly',
+  'freebsd',
+  'hurd',
+  'illumos',
+  'ios',
+  'js',
+  'linux',
+  'nacl',
+  'netbsd',
+  'openbsd',
+  'plan9',
+  'solaris',
+  'wasip1',
+  'windows',
+  'zos',
+] as const;
+
+/** Closed union of Go GOOS values; used internally to enforce membership. */
+type KnownGoOS = (typeof KNOWN_GOOSES_LIST)[number];
+
+/** Exported GOOS type with an escape hatch for unknown Node platforms. */
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type GoOS = KnownGoOS | (string & {});
+
+// Construction-time generic enforces every element is a `KnownGoOS`; the
+// public type widens to `string` so callers can probe with arbitrary input
+// (TypeScript 5.x narrowed `Set<T>.has` to require `T`).
+const KNOWN_GOOSES: ReadonlySet<string> = new Set<KnownGoOS>(KNOWN_GOOSES_LIST);
+
+/**
+ * Unix-like GOOS subset per Go's `internal/syslist.UnixOS` (since Go 1.19).
+ * Construction-time `Set<KnownGoOS>` blocks a typo here (e.g. `'darvin'`).
+ */
+const UNIX_OSES: ReadonlySet<string> = new Set<KnownGoOS>([
   'aix',
   'android',
   'darwin',
@@ -43,53 +84,98 @@ const UNIX_OSES: ReadonlySet<string> = new Set([
   'solaris',
 ]);
 
-function nodePlatformToGoos(p: NodeJS.Platform): string {
-  switch (p) {
-    case 'darwin':
-      return 'darwin';
-    case 'linux':
-      return 'linux';
-    case 'win32':
-      return 'windows';
-    case 'freebsd':
-      return 'freebsd';
-    case 'openbsd':
-      return 'openbsd';
-    case 'sunos':
-      return 'solaris';
-    case 'aix':
-      return 'aix';
-    default:
-      // Best-effort: pass through unknown platforms (e.g. android, cygwin).
-      return p;
-  }
+// === Go GOARCH values ==========================================================
+
+/** Canonical Go `GOARCH` values per `internal/syslist.KnownArch`. */
+const KNOWN_GOARCHES_LIST = [
+  '386',
+  'amd64',
+  'amd64p32',
+  'arm',
+  'arm64',
+  'arm64be',
+  'armbe',
+  'loong64',
+  'mips',
+  'mips64',
+  'mips64le',
+  'mips64p32',
+  'mips64p32le',
+  'mipsle',
+  'ppc',
+  'ppc64',
+  'ppc64le',
+  'riscv',
+  'riscv64',
+  's390',
+  's390x',
+  'sparc',
+  'sparc64',
+  'wasm',
+] as const;
+
+type KnownGoArch = (typeof KNOWN_GOARCHES_LIST)[number];
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type GoArch = KnownGoArch | (string & {});
+
+const KNOWN_GOARCHES: ReadonlySet<string> = new Set<KnownGoArch>(
+  KNOWN_GOARCHES_LIST
+);
+
+export interface BuildContext {
+  readonly goos: GoOS;
+  readonly goarch: GoArch;
+  /** User-supplied tags (e.g. `integration`, `debug`). Default empty. */
+  readonly tags: ReadonlySet<string>;
 }
 
-function nodeArchToGoarch(a: string): string {
-  switch (a) {
-    case 'x64':
-      return 'amd64';
-    case 'ia32':
-      return '386';
-    case 'arm64':
-      return 'arm64';
-    case 'arm':
-      return 'arm';
-    case 'ppc64':
-      return 'ppc64';
-    case 's390x':
-      return 's390x';
-    case 'mips':
-      return 'mips';
-    case 'mipsel':
-      return 'mipsle';
-    case 'riscv64':
-      return 'riscv64';
-    case 'loong64':
-      return 'loong64';
-    default:
-      return a;
-  }
+/**
+ * Mapping from Node's `process.platform` to Go's GOOS. Keys are constrained
+ * to `NodeJS.Platform` and values to `KnownGoOS`, so a typo on either side is
+ * a compile error. Entries are listed only for platforms Go's `internal/syslist`
+ * actually recognizes — others (e.g. Node's `haiku`, `cygwin`) fall through to
+ * the original value in `nodePlatformToGoos`.
+ */
+const NODE_PLATFORM_TO_GOOS: Readonly<
+  Partial<Record<NodeJS.Platform, KnownGoOS>>
+> = {
+  aix: 'aix',
+  android: 'android',
+  darwin: 'darwin',
+  freebsd: 'freebsd',
+  linux: 'linux',
+  netbsd: 'netbsd',
+  openbsd: 'openbsd',
+  sunos: 'solaris',
+  win32: 'windows',
+};
+
+/**
+ * Mapping from Node's `process.arch` to Go's GOARCH. Values are constrained to
+ * `KnownGoArch`. The only non-identity rename is `mipsel → mipsle` (Node spells
+ * it the former, Go the latter).
+ */
+const NODE_ARCH_TO_GOARCH: Readonly<Record<string, KnownGoArch>> = {
+  arm: 'arm',
+  arm64: 'arm64',
+  ia32: '386',
+  loong64: 'loong64',
+  mips: 'mips',
+  mipsel: 'mipsle',
+  ppc64: 'ppc64',
+  riscv64: 'riscv64',
+  s390x: 's390x',
+  x64: 'amd64',
+};
+
+function nodePlatformToGoos(p: NodeJS.Platform): GoOS {
+  // Best-effort: unknown Node platforms (e.g. cygwin, haiku) pass through.
+  return NODE_PLATFORM_TO_GOOS[p] ?? p;
+}
+
+function nodeArchToGoarch(a: string): GoArch {
+  return NODE_ARCH_TO_GOARCH[a] ?? a;
 }
 
 /**
@@ -100,6 +186,7 @@ export function getDefaultBuildContext(): BuildContext {
   return {
     goos: nodePlatformToGoos(platform()),
     goarch: nodeArchToGoarch(arch()),
+    tags: new Set(),
   };
 }
 
@@ -107,16 +194,76 @@ export function getDefaultBuildContext(): BuildContext {
  * Decide whether a Go source file should be considered for import
  * extraction given its content and a build context. Returns `true` when
  * no recognized build constraint is present.
+ *
+ * @param sourceLabel - Optional identifier (typically a file path) used
+ *   in warning messages when the evaluator hits a malformed-expression
+ *   fallback. Omit it to silence those warnings (the unit tests do).
  */
-export function shouldIncludeFile(content: string, ctx: BuildContext): boolean {
+export function shouldIncludeFile(
+  content: string,
+  ctx: BuildContext,
+  sourceLabel?: string
+): boolean {
   const { goBuild, plusBuild } = readHeaderConstraints(content);
   if (goBuild !== null) {
-    return evaluateGoBuild(goBuild, ctx);
+    return evaluateGoBuild(goBuild, ctx, sourceLabel);
   }
   if (plusBuild.length > 0) {
     // Multiple `// +build` lines are AND'd per the legacy spec.
     return plusBuild.every((line) => evaluateLegacyLine(line, ctx));
   }
+  return true;
+}
+
+/**
+ * Decide whether a Go source file should be considered for import
+ * extraction based on its filename, honoring Go's implicit platform
+ * suffix rules. Returns `true` when the filename carries no recognized
+ * suffix or when the suffix matches `ctx`.
+ *
+ * Recognized patterns (Go's `go/build` algorithm, simplified):
+ *  - `name_<GOOS>.go`         — gates on GOOS
+ *  - `name_<GOARCH>.go`       — gates on GOARCH
+ *  - `name_<GOOS>_<GOARCH>.go` — gates on both
+ *  - any of the above with `_test` appended before `.go`
+ *
+ * "Known" GOOS/GOARCH means the value appears in Go's `internal/syslist`.
+ * A name like `nethelper.go` whose tokens don't match either set is
+ * treated as unconstrained.
+ *
+ * @param filePath - Full path or basename — directory parts are stripped.
+ */
+export function shouldIncludeFilename(
+  filePath: string,
+  ctx: BuildContext
+): boolean {
+  const basename = filePath.split(/[/\\]/).pop() ?? filePath;
+  if (!basename.endsWith('.go')) return true;
+
+  let stem = basename.slice(0, -'.go'.length);
+  if (stem.endsWith('_test')) {
+    stem = stem.slice(0, -'_test'.length);
+  }
+
+  const parts = stem.split('_');
+  if (parts.length === 0) return true;
+
+  const last = parts[parts.length - 1];
+  const secondLast = parts.length >= 2 ? parts[parts.length - 2] : '';
+
+  // Last-two match a known GOOS/GOARCH pair (order matters per Go spec).
+  if (
+    parts.length >= 2 &&
+    KNOWN_GOOSES.has(secondLast) &&
+    KNOWN_GOARCHES.has(last)
+  ) {
+    return secondLast === ctx.goos && last === ctx.goarch;
+  }
+
+  // Last alone matches a known GOOS or GOARCH.
+  if (KNOWN_GOOSES.has(last)) return last === ctx.goos;
+  if (KNOWN_GOARCHES.has(last)) return last === ctx.goarch;
+
   return true;
 }
 
@@ -138,17 +285,41 @@ function readHeaderConstraints(content: string): {
     if (line.startsWith('package ') || line === 'package') {
       break;
     }
-    if (line.startsWith('//go:build')) {
-      // Per spec: the first build constraint in the file wins.
+    if (isGoBuildLine(line)) {
+      // The Go spec allows at most one `//go:build` line; `gofmt` and
+      // `go vet` flag duplicates as an error. We tolerate them and take
+      // the first as a leniency choice — failing the graph over a
+      // stylistic issue is worse than silently ignoring the later lines.
       if (goBuild === null) {
         goBuild = line.slice('//go:build'.length).trim();
       }
-    } else if (line.startsWith('// +build')) {
+    } else if (isPlusBuildLine(line)) {
       plusBuild.push(line);
     }
   }
 
   return { goBuild, plusBuild };
+}
+
+/**
+ * Strict directive matchers: the directive token must be followed by
+ * whitespace or end-of-line. A plain `startsWith` would accept
+ * `//go:buildfoo` or `// +builder` as if they were directives.
+ */
+function isGoBuildLine(line: string): boolean {
+  return (
+    line === '//go:build' ||
+    line.startsWith('//go:build ') ||
+    line.startsWith('//go:build\t')
+  );
+}
+
+function isPlusBuildLine(line: string): boolean {
+  return (
+    line === '// +build' ||
+    line.startsWith('// +build ') ||
+    line.startsWith('// +build\t')
+  );
 }
 
 // --- //go:build expression evaluator ---------------------------------------
@@ -162,22 +333,44 @@ interface ParseState {
   pos: number;
 }
 
-function evaluateGoBuild(expr: string, ctx: BuildContext): boolean {
-  const tokens = tokenize(expr);
+function evaluateGoBuild(
+  expr: string,
+  ctx: BuildContext,
+  sourceLabel?: string
+): boolean {
+  const tokens = tokenize(expr, sourceLabel);
   if (tokens.length === 0) {
     // Empty `//go:build` is invalid per spec; fall back to include rather
     // than excluding the file on a malformed constraint.
+    if (sourceLabel) {
+      logger.warn(
+        `Empty //go:build constraint in ${sourceLabel} — treating file as unconstrained.`
+      );
+    }
     return true;
   }
   const state: ParseState = { tokens, pos: 0 };
   const result = parseOr(state, ctx);
   // Extra tokens or unbalanced parens → treat as include (safe fallback).
-  if (state.pos < state.tokens.length) return true;
+  // This catches a common authoring mistake: terms separated by spaces
+  // instead of `&&`/`||`. Without a warning the typo silently masquerades
+  // as "include the file on every platform."
+  if (state.pos < state.tokens.length) {
+    if (sourceLabel) {
+      logger.warn(
+        `Build constraint "//go:build ${expr}" in ${sourceLabel} had ` +
+          `trailing tokens after a complete expression; including the file. ` +
+          `Did you mean && or || between terms?`
+      );
+    }
+    return true;
+  }
   return result;
 }
 
-function tokenize(expr: string): Token[] {
+function tokenize(expr: string, sourceLabel?: string): Token[] {
   const tokens: Token[] = [];
+  const skipped: string[] = [];
   let i = 0;
   while (i < expr.length) {
     const c = expr[i];
@@ -219,7 +412,16 @@ function tokenize(expr: string): Token[] {
     }
     // Unknown character: skip rather than throw. A build constraint is
     // never worth failing graph construction over.
+    skipped.push(c);
     i++;
+  }
+  if (sourceLabel && skipped.length > 0) {
+    logger.warn(
+      `Build constraint "//go:build ${expr}" in ${sourceLabel} contained ` +
+        `unrecognized characters (${JSON.stringify(
+          skipped.join('')
+        )}); they were ignored.`
+    );
   }
   return tokens;
 }
@@ -253,6 +455,13 @@ function parseAnd(s: ParseState, ctx: BuildContext): boolean {
 function parseUnary(s: ParseState, ctx: BuildContext): boolean {
   if (peek(s)?.kind === '!') {
     s.pos++;
+    if (!peek(s)) {
+      // `!` with no operand. Falling through to `parsePrimary` returns
+      // its EOF safe-include of `true`, which the negation would flip to
+      // `false` — silently *excluding* the file and violating the
+      // over-include policy. Short-circuit to `true` instead.
+      return true;
+    }
     return !parseUnary(s, ctx);
   }
   return parsePrimary(s, ctx);
@@ -317,6 +526,6 @@ function matchTag(tag: string, ctx: BuildContext): boolean {
   if (/^go1\.\d+$/.test(tag)) return true;
   // We never invoke cgo from static analysis.
   if (tag === 'cgo') return false;
-  if (ctx.tags?.has(tag)) return true;
+  if (ctx.tags.has(tag)) return true;
   return false;
 }

--- a/packages/gonx/src/graph/static-analysis/extract-imports.spec.ts
+++ b/packages/gonx/src/graph/static-analysis/extract-imports.spec.ts
@@ -302,10 +302,42 @@ describe('extractImports', () => {
       const onLinux = await extractImports(filePath, {
         goos: 'linux',
         goarch: 'amd64',
+        tags: new Set(),
       });
       const onWindows = await extractImports(filePath, {
         goos: 'windows',
         goarch: 'amd64',
+        tags: new Set(),
+      });
+
+      expect(onLinux).toEqual(['fmt']);
+      expect(onWindows).toEqual([]);
+    });
+
+    it('skips files excluded by filename suffix (no in-source directive)', async () => {
+      // `foo_linux.go` is implicitly linux-only via Go's filename rules,
+      // with no //go:build line in the source.
+      const filePath = join(tempDir, 'signal_linux.go');
+      await writeFile(
+        filePath,
+        stripIndent(`
+          package main
+
+          import "fmt"
+
+          func main() { fmt.Println("linux only") }
+        `)
+      );
+
+      const onLinux = await extractImports(filePath, {
+        goos: 'linux',
+        goarch: 'amd64',
+        tags: new Set(),
+      });
+      const onWindows = await extractImports(filePath, {
+        goos: 'windows',
+        goarch: 'amd64',
+        tags: new Set(),
       });
 
       expect(onLinux).toEqual(['fmt']);

--- a/packages/gonx/src/graph/static-analysis/extract-imports.spec.ts
+++ b/packages/gonx/src/graph/static-analysis/extract-imports.spec.ts
@@ -282,4 +282,34 @@ describe('extractImports', () => {
       expect(imports).toEqual(['fmt', 'os', 'github.com/myorg/shared']);
     });
   });
+
+  describe('build constraints', () => {
+    it('skips files excluded by //go:build for the given context', async () => {
+      const filePath = join(tempDir, 'plat.go');
+      await writeFile(
+        filePath,
+        stripIndent(`
+          //go:build linux
+
+          package main
+
+          import "fmt"
+
+          func main() { fmt.Println("linux only") }
+        `)
+      );
+
+      const onLinux = await extractImports(filePath, {
+        goos: 'linux',
+        goarch: 'amd64',
+      });
+      const onWindows = await extractImports(filePath, {
+        goos: 'windows',
+        goarch: 'amd64',
+      });
+
+      expect(onLinux).toEqual(['fmt']);
+      expect(onWindows).toEqual([]);
+    });
+  });
 });

--- a/packages/gonx/src/graph/static-analysis/extract-imports.ts
+++ b/packages/gonx/src/graph/static-analysis/extract-imports.ts
@@ -1,6 +1,14 @@
 import { readFile } from 'fs/promises';
 import { logger } from '@nx/devkit';
+import {
+  BuildContext,
+  getDefaultBuildContext,
+  shouldIncludeFile,
+} from './build-constraints';
 import { initParser, SyntaxNode } from './parser-init';
+
+// Memoized for the lifetime of the process: GOOS/GOARCH don't change.
+const DEFAULT_BUILD_CONTEXT = getDefaultBuildContext();
 
 /**
  * Extracts import paths from a Go source file using tree-sitter.
@@ -15,10 +23,18 @@ import { initParser, SyntaxNode } from './parser-init';
  *
  * Filters out the cgo pseudo-import "C".
  *
+ * Files excluded by their `//go:build` or `// +build` constraints for the
+ * current platform are skipped — they contribute no edges to the graph.
+ *
  * @param filePath - Path to the Go source file
+ * @param buildCtx - Optional build context override. Defaults to the host's
+ *                   GOOS/GOARCH; mainly useful for tests.
  * @returns Array of import paths (excluding "C")
  */
-export async function extractImports(filePath: string): Promise<string[]> {
+export async function extractImports(
+  filePath: string,
+  buildCtx: BuildContext = DEFAULT_BUILD_CONTEXT
+): Promise<string[]> {
   let content: string;
 
   try {
@@ -37,6 +53,12 @@ export async function extractImports(filePath: string): Promise<string[]> {
   }
 
   if (!content.trim()) {
+    return [];
+  }
+
+  // Honor `//go:build` / `// +build` constraints — a file gated to a
+  // different platform contributes no edges on this host.
+  if (!shouldIncludeFile(content, buildCtx)) {
     return [];
   }
 

--- a/packages/gonx/src/graph/static-analysis/extract-imports.ts
+++ b/packages/gonx/src/graph/static-analysis/extract-imports.ts
@@ -4,6 +4,7 @@ import {
   BuildContext,
   getDefaultBuildContext,
   shouldIncludeFile,
+  shouldIncludeFilename,
 } from './build-constraints';
 import { initParser, SyntaxNode } from './parser-init';
 
@@ -35,6 +36,12 @@ export async function extractImports(
   filePath: string,
   buildCtx: BuildContext = DEFAULT_BUILD_CONTEXT
 ): Promise<string[]> {
+  // Filename-suffix constraints are the cheapest check — skip the file
+  // read and parse entirely if `foo_linux.go` is on a Windows host.
+  if (!shouldIncludeFilename(filePath, buildCtx)) {
+    return [];
+  }
+
   let content: string;
 
   try {
@@ -57,8 +64,10 @@ export async function extractImports(
   }
 
   // Honor `//go:build` / `// +build` constraints — a file gated to a
-  // different platform contributes no edges on this host.
-  if (!shouldIncludeFile(content, buildCtx)) {
+  // different platform contributes no edges on this host. Pass the file
+  // path so the evaluator can attribute any malformed-constraint warnings
+  // to the source.
+  if (!shouldIncludeFile(content, buildCtx, filePath)) {
     return [];
   }
 


### PR DESCRIPTION
Closes #101, #107, #109, #110, #111, #112.

## What

Adds in-source Go build-constraint evaluation (`//go:build` and legacy `// +build`) to the gonx static-analysis pipeline. A file gated to a different GOOS/GOARCH than the host no longer contributes edges to the project graph.

Now also includes the review-driven follow-ups from the comprehensive PR review (commit `fix(gonx): address build-tag review findings`) and five of the seven deferred follow-ups (commit `fix(gonx): apply S1/S3/S4/S5/S6 review follow-ups` — landed alongside since they touch the same files).

## Closed by this PR

- #101 — original feature (build-tag evaluation)
- #107 (S1) — literal-union types `GoOS`/`GoArch` with `(string & {})` escape hatch
- #109 (S3) — `BuildContext.tags` now required, empty-set default
- #110 (S4) — docs/comment nits (gofmt framing, citation, Android in `unix`, `#108` anchor)
- #111 (S5) — `withConstraint` helper used consistently in spec
- #112 (S6) — test pinning that block-comment constraints are not directives

## Tracked for future PRs

- #108 (S2) — `cgoEnabled` + `goVersion` on `BuildContext` (feature, needs design discussion)
- #113 (S7) — freeze default context + cygwin handling (behavior change)
- Test/build import differentiation (#102) and WASM/Jest hardening (#104) from the original gap list

## Behavioral semantics

| Tag form | Behavior |
|---|---|
| GOOS / GOARCH idents (e.g. `linux`, `amd64`) | Match host context |
| `unix` | Matches Linux, Darwin, BSDs, Solaris, AIX, Android, illumos, iOS, dragonfly, hurd (Go's full `internal/syslist.UnixOS`) |
| `go1.X` | Always true (no Go compiler to consult; over-include is safer) |
| `cgo` | Always false (static analysis never runs cgo) |
| Unknown idents | Treated as user tags; false unless in `BuildContext.tags` |
| Malformed expression | Falls back to include + `logger.warn` with file path |

When both `//go:build` and `// +build` are present, modern wins per the Go spec.

## Out of scope

- Filename-based suffixes (`foo_linux.go`) — known gap, separate follow-up
- A `GoPluginOptions` field to set user tags — `BuildContext.tags` plumbing is in place internally; plugin-option surface tracked in #108

## Verification

- `nx test gonx` → **250/250 pass** (was 216 → 237 → 248 → 250 across iterations)
- `tsc --noEmit -p tsconfig.lib.json` → clean
- `tsc --noEmit -p tsconfig.spec.json` → clean
- `nx lint gonx` → 0 errors
- `nx format:check` → clean