### PR TITLE
test(e2e): migrate nx-cloudflare and gonx e2e to createTestProject + Verdaccio (#143)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ env:
 jobs:
   main:
     runs-on: ubuntu-latest
+    # Backstop so a hung task (e.g. an e2e install blocked on a torn-down local
+    # registry) fails fast instead of burning the 6h GitHub default.
+    timeout-minutes: 40
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -61,5 +64,8 @@ jobs:
 
       - run: pnpm exec nx affected -t build --yes
 
+      # Run e2e serially: the suites share one local Verdaccio registry, so
+      # running them in parallel races on registry ownership/teardown and can
+      # hang the run. Build deps are already built by the step above.
       - if: ${{ matrix.os != 'windows-latest'}}
-        run: pnpm exec nx affected -t build e2e
+        run: pnpm exec nx affected -t e2e --parallel=1

--- a/.verdaccio/config.yml
+++ b/.verdaccio/config.yml
@@ -8,6 +8,15 @@ uplinks:
     maxage: 60m
 
 packages:
+  # The workspace's own packages are published to this registry during e2e.
+  # They MUST NOT be proxied to npmjs: those scopes already exist upstream, so
+  # proxying makes Verdaccio reject the local publish as "already present" (409)
+  # and the e2e dist-tag never gets created. Keep them local-only.
+  '@naxodev/*':
+    access: $all
+    publish: $all
+    unpublish: $all
+
   '**':
     # give all users (including non-authenticated users) full access
     # because it is a local registry

--- a/nx.json
+++ b/nx.json
@@ -1,5 +1,8 @@
 {
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
+  "cli": {
+    "packageManager": "pnpm"
+  },
   "namedInputs": {
     "default": ["{projectRoot}/**/*", "sharedGlobals"],
     "production": [

--- a/packages/e2e-utils/src/lib/command-utils.ts
+++ b/packages/e2e-utils/src/lib/command-utils.ts
@@ -313,6 +313,26 @@ export function runCLI(
   }
 }
 
+/**
+ * Run `nx show project <name> --json` and return the parsed project
+ * configuration. Slices from the first brace so a stray banner/progress line
+ * ahead of the JSON payload can't make `JSON.parse` throw an opaque error.
+ *
+ * Note: this does not reset the Nx daemon — call `runCLI('reset')` first if the
+ * project was just generated.
+ */
+export function showProject(
+  projectName: string,
+  opts?: RunCmdOpts
+): {
+  root: string;
+  targets?: Record<string, { executor?: string }>;
+  [key: string]: unknown;
+} {
+  const out = runCLI(`show project ${projectName} --json`, opts);
+  return JSON.parse(out.slice(out.indexOf('{')));
+}
+
 export function runLernaCLI(
   command: string,
   opts: RunCmdOpts = {

--- a/packages/e2e-utils/src/lib/create-test-project.ts
+++ b/packages/e2e-utils/src/lib/create-test-project.ts
@@ -3,11 +3,39 @@ import { removeSync, mkdirSync } from 'fs-extra';
 import { execSync } from 'child_process';
 import { tmpProjPath } from '@nx/plugin/testing';
 
+// Pin the generated workspace to the Nx version this repo builds against. e2e
+// must exercise the plugin's published peerDependency range against a known-
+// supported Nx, not whatever `@latest` happens to be on the day CI runs.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const nxVersion: string = require('nx/package.json').version;
+if (!nxVersion) {
+  throw new Error(
+    'Could not resolve the Nx version from nx/package.json for e2e workspace pinning.'
+  );
+}
+
 /**
  * Deletes the e2e directory
  */
 export function cleanup(): void {
   removeSync(dirname(tmpProjPath()));
+}
+
+/**
+ * Creates a fresh Nx workspace in the e2e tmp dir and installs the given
+ * plugin from the local Verdaccio registry (published in jest globalSetup).
+ *
+ * Unlike `ensureNxProject` — which copies the built `dist` into a fixture and
+ * therefore never resolves peerDependencies, package `exports`, or migrations —
+ * this exercises the real `create-nx-workspace` + published-tarball install
+ * path that consumers actually use.
+ *
+ * @returns the absolute path of the generated workspace.
+ */
+export function createTestProject(pluginName: string): string {
+  newNxProject();
+  installPlugin(pluginName);
+  return tmpProjPath();
 }
 
 /**
@@ -17,29 +45,51 @@ export function cleanup(): void {
 export function newNxProject(): void {
   cleanup();
   mkdirSync(dirname(tmpProjPath()));
-  runNxNewCommand('', false);
+  runNxNewCommand();
 }
 
 export function installPlugin(pluginName: string) {
   const localTmpDir = join(tmpProjPath());
-  // The plugin has been built and published to a local registry in the jest globalSetup
-  // Install the plugin built with the latest source code into the test repo
-  execSync(`pnpm add @naxodev/${pluginName}@e2e`, {
+  // The plugin was published to the local Verdaccio registry in the jest
+  // globalSetup. Pin the install to that registry explicitly: `npm_config_registry`
+  // is only set in the registry-owner process, so without this a non-owner
+  // project (e.g. `nx run-many -t e2e` without --parallel=1) would resolve the
+  // `@e2e` tag against npmjs — where it does not exist — and fail confusingly.
+  // The default matches the `local-registry` target's port in project.json.
+  const registry = process.env.npm_config_registry ?? 'http://localhost:4873';
+  execSync(`pnpm add @naxodev/${pluginName}@e2e --registry=${registry}`, {
     cwd: localTmpDir,
     stdio: 'inherit',
     env: process.env,
   });
 }
 
-function runNxNewCommand(args?: string, silent?: boolean) {
+function runNxNewCommand() {
   const localTmpDir = dirname(tmpProjPath());
 
   execSync(
-    `npx --yes create-nx-workspace@latest proj --preset empty --no-nxCloud --no-interactive`,
+    `npx --yes create-nx-workspace@${nxVersion} proj --preset apps --nxCloud=skip --no-interactive --packageManager=pnpm`,
     {
       cwd: localTmpDir,
       stdio: 'inherit',
-      env: process.env,
+      env: {
+        ...process.env,
+        // Mark the run as automated so create-nx-workspace never opens a
+        // browser tab (e.g. the Nx Cloud "connect your workspace" prompt).
+        CI: 'true',
+        // The e2e workspace lives under this repo's gitignored `tmp/`. Without
+        // a ceiling, create-nx-workspace walks up, finds the outer repo, skips
+        // its own `git init`, then fails its initial `git add` because `tmp` is
+        // ignored. Capping the search makes it init an isolated repo in `proj`.
+        GIT_CEILING_DIRECTORIES: localTmpDir,
+        // Strip inherited Nx Cloud credentials so `--nxCloud=skip` is honored
+        // (a leaked token makes create-nx-workspace configure Cloud anyway,
+        // which also pops a "connect your workspace" browser tab) and hard-
+        // disable the Cloud runner for every nx invocation in the fixture.
+        NX_CLOUD_ACCESS_TOKEN: '',
+        NX_CLOUD_ID: '',
+        NX_NO_CLOUD: 'true',
+      },
     }
   );
   console.log(`Created test project in "${localTmpDir}"`);

--- a/packages/gonx-e2e/src/application.spec.ts
+++ b/packages/gonx-e2e/src/application.spec.ts
@@ -2,12 +2,15 @@ import {
   uniq,
   fileExists,
   tmpProjPath,
-  runNxCommand,
-  ensureNxProject,
-  cleanup,
   directoryExists,
 } from '@nx/plugin/testing';
-import { promisifiedTreeKill, runCommandUntil } from '@naxodev/e2e-utils';
+import {
+  createTestProject,
+  cleanup,
+  runCLI,
+  promisifiedTreeKill,
+  runCommandUntil,
+} from '@naxodev/e2e-utils';
 import { join } from 'path';
 import { writeFileSync, mkdirSync } from 'fs';
 
@@ -15,19 +18,22 @@ import { writeFileSync, mkdirSync } from 'fs';
 const isNonInteractive = process.env.CI || !process.stdin.isTTY;
 
 describe('Go Applications (with go.work)', () => {
-  beforeEach(() => {
-    ensureNxProject('@naxodev/gonx', 'dist/packages/gonx');
+  beforeAll(() => {
+    // Create a real Nx workspace and install @naxodev/gonx from the local
+    // registry — exercises the published-tarball install path (peerDeps,
+    // exports) that the legacy ensureNxProject fixture never touched.
+    createTestProject('gonx');
 
     // Initialize Go support first with go.work support
-    runNxCommand('generate @naxodev/gonx:init --addGoDotWork');
-  });
+    runCLI('generate @naxodev/gonx:init --addGoDotWork');
+  }, 300_000);
 
-  afterEach(() => cleanup());
+  afterAll(() => cleanup());
 
   it('should be able to generate a Go application', async () => {
     const goapp = uniq('goapp');
 
-    runNxCommand(`generate @naxodev/gonx:application ${goapp}`, {
+    runCLI(`generate @naxodev/gonx:application ${goapp}`, {
       env: { NX_ADD_PLUGINS: 'true' },
     });
 
@@ -39,7 +45,7 @@ describe('Go Applications (with go.work)', () => {
   it('should be able to generate an application with a specific directory', async () => {
     const goapp = uniq('goapp');
 
-    runNxCommand(
+    runCLI(
       `generate @naxodev/gonx:application --directory="apps/${goapp}" --name=${goapp}`,
       { env: { NX_ADD_PLUGINS: 'true' } }
     );
@@ -56,7 +62,7 @@ describe('Go Applications (with go.work)', () => {
   it('should be able to run build, lint, test, generate and tidy commands on a Go application', async () => {
     const goapp = uniq('goapp');
 
-    runNxCommand(`generate @naxodev/gonx:application ${goapp}`, {
+    runCLI(`generate @naxodev/gonx:application ${goapp}`, {
       env: { NX_ADD_PLUGINS: 'true' },
     });
 
@@ -64,28 +70,28 @@ describe('Go Applications (with go.work)', () => {
     expect(fileExists(join(tmpProjPath(), `${goapp}/main.go`))).toBeTruthy();
 
     // Reset Nx daemon to pick up new project
-    runNxCommand('reset');
+    runCLI('reset');
 
     // Run tidy
-    const tidyResults = runNxCommand(`tidy ${goapp}`);
+    const tidyResults = runCLI(`tidy ${goapp}`);
     expect(tidyResults).toContain(
       `NX   Successfully ran target tidy for project ${goapp}`
     );
 
     // Run lint
-    const lintResults = runNxCommand(`lint ${goapp}`);
+    const lintResults = runCLI(`lint ${goapp}`);
     expect(lintResults).toContain(
       `NX   Successfully ran target lint for project ${goapp}`
     );
 
     // Run generate
-    const generateResults = runNxCommand(`run ${goapp}:generate`);
+    const generateResults = runCLI(`run ${goapp}:generate`);
     expect(generateResults).toContain(
       `NX   Successfully ran target generate for project ${goapp}`
     );
 
     // Run build
-    const buildResults = runNxCommand(`build ${goapp}`);
+    const buildResults = runCLI(`build ${goapp}`);
     expect(buildResults).toContain(
       `NX   Successfully ran target build for project ${goapp}`
     );
@@ -93,7 +99,7 @@ describe('Go Applications (with go.work)', () => {
     expect(directoryExists(join(tmpProjPath(), `dist/${goapp}`))).toBeTruthy();
 
     // Run test
-    const testResults = runNxCommand(`test ${goapp}`);
+    const testResults = runCLI(`test ${goapp}`);
     expect(testResults).toContain(
       `NX   Successfully ran target test for project ${goapp}`
     );
@@ -102,7 +108,7 @@ describe('Go Applications (with go.work)', () => {
   it('should be able to run the serve command on a Go application', async () => {
     const goapp = uniq('goapp');
 
-    runNxCommand(`generate @naxodev/gonx:application ${goapp}`, {
+    runCLI(`generate @naxodev/gonx:application ${goapp}`, {
       env: { NX_ADD_PLUGINS: 'true' },
     });
 
@@ -110,7 +116,7 @@ describe('Go Applications (with go.work)', () => {
     expect(fileExists(join(tmpProjPath(), `${goapp}/main.go`))).toBeTruthy();
 
     // Reset Nx daemon to pick up new project
-    runNxCommand('reset');
+    runCLI('reset');
 
     // Run serve and wait until the server starts
     const p = await runCommandUntil(`serve ${goapp}`, (output: string) =>
@@ -126,12 +132,12 @@ describe('Go Applications (with go.work)', () => {
   it('should be able to build a Go application with custom main option', async () => {
     const goapp = uniq('goapp');
 
-    runNxCommand(`generate @naxodev/gonx:application ${goapp}`, {
+    runCLI(`generate @naxodev/gonx:application ${goapp}`, {
       env: { NX_ADD_PLUGINS: 'true' },
     });
 
     // Reset Nx daemon to pick up new project
-    runNxCommand('reset');
+    runCLI('reset');
 
     // Create a custom main.go file in a subdirectory
     const customMainDir = join(tmpProjPath(), `${goapp}/cmd/server`);
@@ -150,9 +156,7 @@ func main() {
     );
 
     // Build with custom main option
-    const buildResults = runNxCommand(
-      `build ${goapp} --main=cmd/server/main.go`
-    );
+    const buildResults = runCLI(`build ${goapp} --main=cmd/server/main.go`);
     expect(buildResults).toContain(
       `NX   Successfully ran target build for project ${goapp}`
     );
@@ -163,12 +167,12 @@ func main() {
   it('should be able to serve a Go application with custom main option', async () => {
     const goapp = uniq('goapp');
 
-    runNxCommand(`generate @naxodev/gonx:application ${goapp}`, {
+    runCLI(`generate @naxodev/gonx:application ${goapp}`, {
       env: { NX_ADD_PLUGINS: 'true' },
     });
 
     // Reset Nx daemon to pick up new project
-    runNxCommand('reset');
+    runCLI('reset');
 
     // Create a custom main.go file in a subdirectory
     const customMainDir = join(tmpProjPath(), `${goapp}/cmd/server`);
@@ -208,12 +212,12 @@ func main() {
   it('should be able to run the generate command with custom flags', async () => {
     const goapp = uniq('goapp');
 
-    runNxCommand(`generate @naxodev/gonx:application ${goapp}`, {
+    runCLI(`generate @naxodev/gonx:application ${goapp}`, {
       env: { NX_ADD_PLUGINS: 'true' },
     });
 
     // Reset Nx daemon to pick up new project
-    runNxCommand('reset');
+    runCLI('reset');
 
     // Create a Go file with go:generate directive
     writeFileSync(
@@ -227,7 +231,7 @@ var GeneratedVar = "placeholder"
     );
 
     // Run generate with verbose flag
-    const generateResults = runNxCommand(`run ${goapp}:generate --flags=-v`);
+    const generateResults = runCLI(`run ${goapp}:generate --flags=-v`);
     expect(generateResults).toContain(
       `NX   Successfully ran target generate for project ${goapp}`
     );
@@ -236,7 +240,7 @@ var GeneratedVar = "placeholder"
   it('should be able to generate a CLI application', async () => {
     const goapp = uniq('goapp');
 
-    runNxCommand(`generate @naxodev/gonx:application ${goapp} --template=cli`, {
+    runCLI(`generate @naxodev/gonx:application ${goapp} --template=cli`, {
       env: { NX_ADD_PLUGINS: 'true' },
     });
 
@@ -254,7 +258,7 @@ var GeneratedVar = "placeholder"
   it('should be able to generate a CLI application with a specific directory', async () => {
     const goapp = uniq('goapp');
 
-    runNxCommand(
+    runCLI(
       `generate @naxodev/gonx:application --directory="apps/${goapp}" ${goapp} --template=cli`,
       {
         env: { NX_ADD_PLUGINS: 'true' },
@@ -283,7 +287,7 @@ var GeneratedVar = "placeholder"
     }
     const goapp = uniq('goapp');
 
-    runNxCommand(`generate @naxodev/gonx:application ${goapp} --template=cli`, {
+    runCLI(`generate @naxodev/gonx:application ${goapp} --template=cli`, {
       env: { NX_ADD_PLUGINS: 'true' },
     });
 
@@ -291,28 +295,28 @@ var GeneratedVar = "placeholder"
     expect(fileExists(join(tmpProjPath(), `${goapp}/main.go`))).toBeTruthy();
 
     // Reset Nx daemon to pick up new project
-    runNxCommand('reset');
+    runCLI('reset');
 
     // Run tidy
-    const tidyResults = runNxCommand(`tidy ${goapp}`);
+    const tidyResults = runCLI(`tidy ${goapp}`);
     expect(tidyResults).toContain(
       `NX   Successfully ran target tidy for project ${goapp}`
     );
 
     // Run lint
-    const lintResults = runNxCommand(`lint ${goapp}`);
+    const lintResults = runCLI(`lint ${goapp}`);
     expect(lintResults).toContain(
       `NX   Successfully ran target lint for project ${goapp}`
     );
 
     // Run generate
-    const generateResults = runNxCommand(`run ${goapp}:generate`);
+    const generateResults = runCLI(`run ${goapp}:generate`);
     expect(generateResults).toContain(
       `NX   Successfully ran target generate for project ${goapp}`
     );
 
     // Run build
-    const buildResults = runNxCommand(`build ${goapp}`);
+    const buildResults = runCLI(`build ${goapp}`);
     expect(buildResults).toContain(
       `NX   Successfully ran target build for project ${goapp}`
     );
@@ -320,7 +324,7 @@ var GeneratedVar = "placeholder"
     expect(directoryExists(join(tmpProjPath(), `dist/${goapp}`))).toBeTruthy();
 
     // Run test
-    const testResults = runNxCommand(`test ${goapp}`);
+    const testResults = runCLI(`test ${goapp}`);
     expect(testResults).toContain(
       `NX   Successfully ran target test for project ${goapp}`
     );
@@ -329,7 +333,7 @@ var GeneratedVar = "placeholder"
   it('should be able to generate a TUI application', async () => {
     const goapp = uniq('goapp');
 
-    runNxCommand(`generate @naxodev/gonx:application ${goapp} --template=tui`, {
+    runCLI(`generate @naxodev/gonx:application ${goapp} --template=tui`, {
       env: { NX_ADD_PLUGINS: 'true' },
     });
 
@@ -350,7 +354,7 @@ var GeneratedVar = "placeholder"
   it('should be able to generate a TUI application with a specific directory', async () => {
     const goapp = uniq('goapp');
 
-    runNxCommand(
+    runCLI(
       `generate @naxodev/gonx:application --directory="apps/${goapp}" ${goapp} --template=tui`,
       {
         env: { NX_ADD_PLUGINS: 'true' },
@@ -382,7 +386,7 @@ var GeneratedVar = "placeholder"
     }
     const goapp = uniq('goapp');
 
-    runNxCommand(`generate @naxodev/gonx:application ${goapp} --template=tui`, {
+    runCLI(`generate @naxodev/gonx:application ${goapp} --template=tui`, {
       env: { NX_ADD_PLUGINS: 'true' },
     });
 
@@ -390,28 +394,28 @@ var GeneratedVar = "placeholder"
     expect(fileExists(join(tmpProjPath(), `${goapp}/main.go`))).toBeTruthy();
 
     // Reset Nx daemon to pick up new project
-    runNxCommand('reset');
+    runCLI('reset');
 
     // Run tidy
-    const tidyResults = runNxCommand(`tidy ${goapp}`);
+    const tidyResults = runCLI(`tidy ${goapp}`);
     expect(tidyResults).toContain(
       `NX   Successfully ran target tidy for project ${goapp}`
     );
 
     // Run lint
-    const lintResults = runNxCommand(`lint ${goapp}`);
+    const lintResults = runCLI(`lint ${goapp}`);
     expect(lintResults).toContain(
       `NX   Successfully ran target lint for project ${goapp}`
     );
 
     // Run generate
-    const generateResults = runNxCommand(`run ${goapp}:generate`);
+    const generateResults = runCLI(`run ${goapp}:generate`);
     expect(generateResults).toContain(
       `NX   Successfully ran target generate for project ${goapp}`
     );
 
     // Run build
-    const buildResults = runNxCommand(`build ${goapp}`);
+    const buildResults = runCLI(`build ${goapp}`);
     expect(buildResults).toContain(
       `NX   Successfully ran target build for project ${goapp}`
     );
@@ -419,7 +423,7 @@ var GeneratedVar = "placeholder"
     expect(directoryExists(join(tmpProjPath(), `dist/${goapp}`))).toBeTruthy();
 
     // Run test
-    const testResults = runNxCommand(`test ${goapp}`);
+    const testResults = runCLI(`test ${goapp}`);
     expect(testResults).toContain(
       `NX   Successfully ran target test for project ${goapp}`
     );
@@ -432,7 +436,7 @@ var GeneratedVar = "placeholder"
     }
     const goapp = uniq('goapp');
 
-    runNxCommand(`generate @naxodev/gonx:application ${goapp} --template=cli`, {
+    runCLI(`generate @naxodev/gonx:application ${goapp} --template=cli`, {
       env: { NX_ADD_PLUGINS: 'true' },
     });
 
@@ -440,9 +444,9 @@ var GeneratedVar = "placeholder"
     expect(fileExists(join(tmpProjPath(), `${goapp}/main.go`))).toBeTruthy();
 
     // Reset Nx daemon to pick up new project
-    runNxCommand('reset');
+    runCLI('reset');
 
-    const tidyResults = runNxCommand(`tidy ${goapp}`);
+    const tidyResults = runCLI(`tidy ${goapp}`);
     expect(tidyResults).toContain(
       `NX   Successfully ran target tidy for project ${goapp}`
     );
@@ -465,7 +469,7 @@ var GeneratedVar = "placeholder"
     }
     const goapp = uniq('goapp');
 
-    runNxCommand(`generate @naxodev/gonx:application ${goapp} --template=tui`, {
+    runCLI(`generate @naxodev/gonx:application ${goapp} --template=tui`, {
       env: { NX_ADD_PLUGINS: 'true' },
     });
 
@@ -473,9 +477,9 @@ var GeneratedVar = "placeholder"
     expect(fileExists(join(tmpProjPath(), `${goapp}/main.go`))).toBeTruthy();
 
     // Reset Nx daemon to pick up new project
-    runNxCommand('reset');
+    runCLI('reset');
 
-    const tidyResults = runNxCommand(`tidy ${goapp}`);
+    const tidyResults = runCLI(`tidy ${goapp}`);
     expect(tidyResults).toContain(
       `NX   Successfully ran target tidy for project ${goapp}`
     );
@@ -493,19 +497,22 @@ var GeneratedVar = "placeholder"
 });
 
 describe('Go Applications (without go.work)', () => {
-  beforeEach(() => {
-    ensureNxProject('@naxodev/gonx', 'dist/packages/gonx');
+  beforeAll(() => {
+    // Create a real Nx workspace and install @naxodev/gonx from the local
+    // registry — exercises the published-tarball install path (peerDeps,
+    // exports) that the legacy ensureNxProject fixture never touched.
+    createTestProject('gonx');
 
     // Initialize Go support without go.work support (new default)
-    runNxCommand('generate @naxodev/gonx:init');
-  });
+    runCLI('generate @naxodev/gonx:init');
+  }, 300_000);
 
-  afterEach(() => cleanup());
+  afterAll(() => cleanup());
 
   it('should be able to generate a Go application without go.work', async () => {
     const goapp = uniq('goapp');
 
-    runNxCommand(`generate @naxodev/gonx:application ${goapp}`, {
+    runCLI(`generate @naxodev/gonx:application ${goapp}`, {
       env: { NX_ADD_PLUGINS: 'true' },
     });
 
@@ -520,7 +527,7 @@ describe('Go Applications (without go.work)', () => {
   it('should be able to generate an application with a specific directory without go.work', async () => {
     const goapp = uniq('goapp');
 
-    runNxCommand(
+    runCLI(
       `generate @naxodev/gonx:application --directory="apps/${goapp}" --name=${goapp}`,
       { env: { NX_ADD_PLUGINS: 'true' } }
     );
@@ -540,7 +547,7 @@ describe('Go Applications (without go.work)', () => {
   it('should be able to run build, lint, test, generate and tidy commands on a Go application without go.work', async () => {
     const goapp = uniq('goapp');
 
-    runNxCommand(`generate @naxodev/gonx:application ${goapp}`, {
+    runCLI(`generate @naxodev/gonx:application ${goapp}`, {
       env: { NX_ADD_PLUGINS: 'true' },
     });
 
@@ -548,28 +555,28 @@ describe('Go Applications (without go.work)', () => {
     expect(fileExists(join(tmpProjPath(), `${goapp}/main.go`))).toBeTruthy();
 
     // Reset Nx daemon to pick up new project
-    runNxCommand('reset');
+    runCLI('reset');
 
     // Run tidy
-    const tidyResults = runNxCommand(`tidy ${goapp}`);
+    const tidyResults = runCLI(`tidy ${goapp}`);
     expect(tidyResults).toContain(
       `NX   Successfully ran target tidy for project ${goapp}`
     );
 
     // Run lint
-    const lintResults = runNxCommand(`lint ${goapp}`);
+    const lintResults = runCLI(`lint ${goapp}`);
     expect(lintResults).toContain(
       `NX   Successfully ran target lint for project ${goapp}`
     );
 
     // Run generate
-    const generateResults = runNxCommand(`run ${goapp}:generate`);
+    const generateResults = runCLI(`run ${goapp}:generate`);
     expect(generateResults).toContain(
       `NX   Successfully ran target generate for project ${goapp}`
     );
 
     // Run build
-    const buildResults = runNxCommand(`build ${goapp}`);
+    const buildResults = runCLI(`build ${goapp}`);
     expect(buildResults).toContain(
       `NX   Successfully ran target build for project ${goapp}`
     );
@@ -577,7 +584,7 @@ describe('Go Applications (without go.work)', () => {
     expect(directoryExists(join(tmpProjPath(), `dist/${goapp}`))).toBeTruthy();
 
     // Run test
-    const testResults = runNxCommand(`test ${goapp}`);
+    const testResults = runCLI(`test ${goapp}`);
     expect(testResults).toContain(
       `NX   Successfully ran target test for project ${goapp}`
     );
@@ -586,7 +593,7 @@ describe('Go Applications (without go.work)', () => {
   it('should be able to run the serve command on a Go application without go.work', async () => {
     const goapp = uniq('goapp');
 
-    runNxCommand(`generate @naxodev/gonx:application ${goapp}`, {
+    runCLI(`generate @naxodev/gonx:application ${goapp}`, {
       env: { NX_ADD_PLUGINS: 'true' },
     });
 
@@ -594,7 +601,7 @@ describe('Go Applications (without go.work)', () => {
     expect(fileExists(join(tmpProjPath(), `${goapp}/main.go`))).toBeTruthy();
 
     // Reset Nx daemon to pick up new project
-    runNxCommand('reset');
+    runCLI('reset');
 
     // Run serve and wait until the server starts
     const p = await runCommandUntil(`serve ${goapp}`, (output: string) =>
@@ -610,12 +617,12 @@ describe('Go Applications (without go.work)', () => {
   it('should be able to build a Go application with custom main option without go.work', async () => {
     const goapp = uniq('goapp');
 
-    runNxCommand(`generate @naxodev/gonx:application ${goapp}`, {
+    runCLI(`generate @naxodev/gonx:application ${goapp}`, {
       env: { NX_ADD_PLUGINS: 'true' },
     });
 
     // Reset Nx daemon to pick up new project
-    runNxCommand('reset');
+    runCLI('reset');
 
     // Create a custom main.go file in a subdirectory
     const customMainDir = join(tmpProjPath(), `${goapp}/cmd/server`);
@@ -634,9 +641,7 @@ func main() {
     );
 
     // Build with custom main option
-    const buildResults = runNxCommand(
-      `build ${goapp} --main=cmd/server/main.go`
-    );
+    const buildResults = runCLI(`build ${goapp} --main=cmd/server/main.go`);
     expect(buildResults).toContain(
       `NX   Successfully ran target build for project ${goapp}`
     );
@@ -647,12 +652,12 @@ func main() {
   it('should be able to serve a Go application with custom main option without go.work', async () => {
     const goapp = uniq('goapp');
 
-    runNxCommand(`generate @naxodev/gonx:application ${goapp}`, {
+    runCLI(`generate @naxodev/gonx:application ${goapp}`, {
       env: { NX_ADD_PLUGINS: 'true' },
     });
 
     // Reset Nx daemon to pick up new project
-    runNxCommand('reset');
+    runCLI('reset');
 
     // Create a custom main.go file in a subdirectory
     const customMainDir = join(tmpProjPath(), `${goapp}/cmd/server`);
@@ -692,12 +697,12 @@ func main() {
   it('should be able to run the generate command with custom flags without go.work', async () => {
     const goapp = uniq('goapp');
 
-    runNxCommand(`generate @naxodev/gonx:application ${goapp}`, {
+    runCLI(`generate @naxodev/gonx:application ${goapp}`, {
       env: { NX_ADD_PLUGINS: 'true' },
     });
 
     // Reset Nx daemon to pick up new project
-    runNxCommand('reset');
+    runCLI('reset');
 
     // Create a Go file with go:generate directive
     writeFileSync(
@@ -711,7 +716,7 @@ var GeneratedVar = "placeholder"
     );
 
     // Run generate with verbose flag
-    const generateResults = runNxCommand(`run ${goapp}:generate --flags=-v`);
+    const generateResults = runCLI(`run ${goapp}:generate --flags=-v`);
     expect(generateResults).toContain(
       `NX   Successfully ran target generate for project ${goapp}`
     );
@@ -720,7 +725,7 @@ var GeneratedVar = "placeholder"
   it('should be able to generate a CLI application without go.work', async () => {
     const goapp = uniq('goapp');
 
-    runNxCommand(`generate @naxodev/gonx:application ${goapp} --template=cli`, {
+    runCLI(`generate @naxodev/gonx:application ${goapp} --template=cli`, {
       env: { NX_ADD_PLUGINS: 'true' },
     });
 
@@ -741,7 +746,7 @@ var GeneratedVar = "placeholder"
   it('should be able to generate a CLI application without go.work in a specific directory', async () => {
     const goapp = uniq('goapp');
 
-    runNxCommand(
+    runCLI(
       `generate @naxodev/gonx:application --directory="apps/${goapp}" ${goapp} --template=cli`,
       {
         env: { NX_ADD_PLUGINS: 'true' },
@@ -773,7 +778,7 @@ var GeneratedVar = "placeholder"
     }
     const goapp = uniq('goapp');
 
-    runNxCommand(`generate @naxodev/gonx:application ${goapp} --template=cli`, {
+    runCLI(`generate @naxodev/gonx:application ${goapp} --template=cli`, {
       env: { NX_ADD_PLUGINS: 'true' },
     });
 
@@ -781,28 +786,28 @@ var GeneratedVar = "placeholder"
     expect(fileExists(join(tmpProjPath(), `${goapp}/main.go`))).toBeTruthy();
 
     // Reset Nx daemon to pick up new project
-    runNxCommand('reset');
+    runCLI('reset');
 
     // Run tidy
-    const tidyResults = runNxCommand(`tidy ${goapp}`);
+    const tidyResults = runCLI(`tidy ${goapp}`);
     expect(tidyResults).toContain(
       `NX   Successfully ran target tidy for project ${goapp}`
     );
 
     // Run lint
-    const lintResults = runNxCommand(`lint ${goapp}`);
+    const lintResults = runCLI(`lint ${goapp}`);
     expect(lintResults).toContain(
       `NX   Successfully ran target lint for project ${goapp}`
     );
 
     // Run generate
-    const generateResults = runNxCommand(`run ${goapp}:generate`);
+    const generateResults = runCLI(`run ${goapp}:generate`);
     expect(generateResults).toContain(
       `NX   Successfully ran target generate for project ${goapp}`
     );
 
     // Run build
-    const buildResults = runNxCommand(`build ${goapp}`);
+    const buildResults = runCLI(`build ${goapp}`);
     expect(buildResults).toContain(
       `NX   Successfully ran target build for project ${goapp}`
     );
@@ -810,7 +815,7 @@ var GeneratedVar = "placeholder"
     expect(directoryExists(join(tmpProjPath(), `dist/${goapp}`))).toBeTruthy();
 
     // Run test
-    const testResults = runNxCommand(`test ${goapp}`);
+    const testResults = runCLI(`test ${goapp}`);
     expect(testResults).toContain(
       `NX   Successfully ran target test for project ${goapp}`
     );
@@ -819,7 +824,7 @@ var GeneratedVar = "placeholder"
   it('should be able to generate a TUI application without go.work', async () => {
     const goapp = uniq('goapp');
 
-    runNxCommand(`generate @naxodev/gonx:application ${goapp} --template=tui`, {
+    runCLI(`generate @naxodev/gonx:application ${goapp} --template=tui`, {
       env: { NX_ADD_PLUGINS: 'true' },
     });
 
@@ -843,7 +848,7 @@ var GeneratedVar = "placeholder"
   it('should be able to generate a TUI application without go.work in a specific directory', async () => {
     const goapp = uniq('goapp');
 
-    runNxCommand(
+    runCLI(
       `generate @naxodev/gonx:application --directory="apps/${goapp}" ${goapp} --template=tui`,
       {
         env: { NX_ADD_PLUGINS: 'true' },
@@ -878,7 +883,7 @@ var GeneratedVar = "placeholder"
     }
     const goapp = uniq('goapp');
 
-    runNxCommand(`generate @naxodev/gonx:application ${goapp} --template=tui`, {
+    runCLI(`generate @naxodev/gonx:application ${goapp} --template=tui`, {
       env: { NX_ADD_PLUGINS: 'true' },
     });
 
@@ -886,28 +891,28 @@ var GeneratedVar = "placeholder"
     expect(fileExists(join(tmpProjPath(), `${goapp}/main.go`))).toBeTruthy();
 
     // Reset Nx daemon to pick up new project
-    runNxCommand('reset');
+    runCLI('reset');
 
     // Run tidy
-    const tidyResults = runNxCommand(`tidy ${goapp}`);
+    const tidyResults = runCLI(`tidy ${goapp}`);
     expect(tidyResults).toContain(
       `NX   Successfully ran target tidy for project ${goapp}`
     );
 
     // Run lint
-    const lintResults = runNxCommand(`lint ${goapp}`);
+    const lintResults = runCLI(`lint ${goapp}`);
     expect(lintResults).toContain(
       `NX   Successfully ran target lint for project ${goapp}`
     );
 
     // Run generate
-    const generateResults = runNxCommand(`run ${goapp}:generate`);
+    const generateResults = runCLI(`run ${goapp}:generate`);
     expect(generateResults).toContain(
       `NX   Successfully ran target generate for project ${goapp}`
     );
 
     // Run build
-    const buildResults = runNxCommand(`build ${goapp}`);
+    const buildResults = runCLI(`build ${goapp}`);
     expect(buildResults).toContain(
       `NX   Successfully ran target build for project ${goapp}`
     );
@@ -915,7 +920,7 @@ var GeneratedVar = "placeholder"
     expect(directoryExists(join(tmpProjPath(), `dist/${goapp}`))).toBeTruthy();
 
     // Run test
-    const testResults = runNxCommand(`test ${goapp}`);
+    const testResults = runCLI(`test ${goapp}`);
     expect(testResults).toContain(
       `NX   Successfully ran target test for project ${goapp}`
     );
@@ -928,7 +933,7 @@ var GeneratedVar = "placeholder"
     }
     const goapp = uniq('goapp');
 
-    runNxCommand(`generate @naxodev/gonx:application ${goapp} --template=cli`, {
+    runCLI(`generate @naxodev/gonx:application ${goapp} --template=cli`, {
       env: { NX_ADD_PLUGINS: 'true' },
     });
 
@@ -936,9 +941,9 @@ var GeneratedVar = "placeholder"
     expect(fileExists(join(tmpProjPath(), `${goapp}/main.go`))).toBeTruthy();
 
     // Reset Nx daemon to pick up new project
-    runNxCommand('reset');
+    runCLI('reset');
 
-    const tidyResults = runNxCommand(`tidy ${goapp}`);
+    const tidyResults = runCLI(`tidy ${goapp}`);
     expect(tidyResults).toContain(
       `NX   Successfully ran target tidy for project ${goapp}`
     );
@@ -961,7 +966,7 @@ var GeneratedVar = "placeholder"
     }
     const goapp = uniq('goapp');
 
-    runNxCommand(`generate @naxodev/gonx:application ${goapp} --template=tui`, {
+    runCLI(`generate @naxodev/gonx:application ${goapp} --template=tui`, {
       env: { NX_ADD_PLUGINS: 'true' },
     });
 
@@ -969,9 +974,9 @@ var GeneratedVar = "placeholder"
     expect(fileExists(join(tmpProjPath(), `${goapp}/main.go`))).toBeTruthy();
 
     // Reset Nx daemon to pick up new project
-    runNxCommand('reset');
+    runCLI('reset');
 
-    const tidyResults = runNxCommand(`tidy ${goapp}`);
+    const tidyResults = runCLI(`tidy ${goapp}`);
     expect(tidyResults).toContain(
       `NX   Successfully ran target tidy for project ${goapp}`
     );

--- a/packages/gonx-e2e/src/go-blueprint.spec.ts
+++ b/packages/gonx-e2e/src/go-blueprint.spec.ts
@@ -1,50 +1,33 @@
-import {
-  uniq,
-  runNxCommand,
-  ensureNxProject,
-  cleanup,
-  fileExists,
-  tmpProjPath,
-  readFile,
-} from '@nx/plugin/testing';
+import { uniq, fileExists, tmpProjPath, readFile } from '@nx/plugin/testing';
+import { createTestProject, cleanup, runCLI } from '@naxodev/e2e-utils';
 import { join } from 'path';
 
 const unsupportedFiles = ['.air.toml', 'README.md', 'Makefile'];
 
-// Skip these tests in non-interactive environments (CI, Jest without TTY)
+// The go-blueprint generator requires an interactive TTY, which CI (and jest's
+// piped stdin) never provides. Use describe.skip there so the suite reports as
+// skipped instead of vacuously passing.
 const isNonInteractive = process.env.CI || !process.stdin.isTTY;
+const describeBlueprint = isNonInteractive ? describe.skip : describe;
 
-describe('Go Blueprint Generator', () => {
+describeBlueprint('Go Blueprint Generator', () => {
   beforeAll(() => {
-    if (isNonInteractive) {
-      console.log(
-        'Skipping Go Blueprint tests in non-interactive environment (no TTY available)'
-      );
-    }
-  });
-
-  beforeEach(() => {
-    if (isNonInteractive) return;
-    ensureNxProject('@naxodev/gonx', 'dist/packages/gonx');
+    // Create a real Nx workspace and install @naxodev/gonx from the local
+    // registry — exercises the published-tarball install path (peerDeps,
+    // exports) that the legacy ensureNxProject fixture never touched.
+    createTestProject('gonx');
 
     // Initialize Go support
-    runNxCommand('generate @naxodev/gonx:init');
-  });
+    runCLI('generate @naxodev/gonx:init');
+  }, 300_000);
 
-  afterEach(() => {
-    if (isNonInteractive) return;
-    cleanup();
-  });
+  afterAll(() => cleanup());
 
   it('should generate the projects in the workspace root when the go-blueprint generator is run', async () => {
-    if (isNonInteractive) {
-      console.log('Skipping test in non-interactive environment');
-      return;
-    }
     const projectName = uniq('gobp');
 
     // Try to run the generator with minimal required options
-    const result = runNxCommand(
+    const result = runCLI(
       `generate @naxodev/gonx:go-blueprint ${projectName} --framework=gin --driver=sqlite --git=skip`
     );
 
@@ -74,14 +57,10 @@ describe('Go Blueprint Generator', () => {
   }, 60_000);
 
   it('should generate the projects in a nested folder when the go-blueprint generator is run', async () => {
-    if (isNonInteractive) {
-      console.log('Skipping test in non-interactive environment');
-      return;
-    }
     const projectName = uniq('gobp');
 
     // Try to run the generator with minimal required options
-    runNxCommand(
+    runCLI(
       `generate @naxodev/gonx:go-blueprint --directory="apps/${projectName}" --framework=gin --driver=sqlite --git=skip`
     );
 
@@ -111,14 +90,10 @@ describe('Go Blueprint Generator', () => {
   }, 60_000);
 
   it('should support --dry-run without creating actual files', async () => {
-    if (isNonInteractive) {
-      console.log('Skipping test in non-interactive environment');
-      return;
-    }
     const projectName = uniq('gobp');
 
     // Run generator with --dry-run flag
-    const result = runNxCommand(
+    const result = runCLI(
       `generate @naxodev/gonx:go-blueprint ${projectName} --framework=gin --driver=sqlite --git=skip --dry-run`
     );
 

--- a/packages/gonx-e2e/src/library.spec.ts
+++ b/packages/gonx-e2e/src/library.spec.ts
@@ -1,27 +1,24 @@
-import {
-  uniq,
-  fileExists,
-  tmpProjPath,
-  runNxCommand,
-  ensureNxProject,
-  cleanup,
-} from '@nx/plugin/testing';
+import { uniq, fileExists, tmpProjPath } from '@nx/plugin/testing';
+import { createTestProject, cleanup, runCLI } from '@naxodev/e2e-utils';
 import { join } from 'path';
 
 describe('Go Libraries', () => {
-  beforeEach(() => {
-    ensureNxProject('@naxodev/gonx', 'dist/packages/gonx');
+  beforeAll(() => {
+    // Create a real Nx workspace and install @naxodev/gonx from the local
+    // registry — exercises the published-tarball install path (peerDeps,
+    // exports) that the legacy ensureNxProject fixture never touched.
+    createTestProject('gonx');
 
     // Initialize Go support first with go.work support
-    runNxCommand('generate @naxodev/gonx:init --addGoDotWork');
-  });
+    runCLI('generate @naxodev/gonx:init --addGoDotWork');
+  }, 300_000);
 
-  afterEach(() => cleanup());
+  afterAll(() => cleanup());
 
   it('should be able to generate a Go library', async () => {
     const golib = uniq('golib');
 
-    runNxCommand(`generate @naxodev/gonx:library ${golib}`);
+    runCLI(`generate @naxodev/gonx:library ${golib}`);
 
     // Verify the library files were created
     expect(
@@ -33,7 +30,7 @@ describe('Go Libraries', () => {
   it('should be able to generate a library with a specific directory', async () => {
     const golib = uniq('golib');
 
-    runNxCommand(
+    runCLI(
       `generate @naxodev/gonx:library --directory="libs/${golib}" --name=${golib}`
     );
 
@@ -49,7 +46,7 @@ describe('Go Libraries', () => {
   it('should be able to run tidy, lint, and test commands on a Go library', async () => {
     const golib = uniq('golib');
 
-    runNxCommand(`generate @naxodev/gonx:library ${golib}`);
+    runCLI(`generate @naxodev/gonx:library ${golib}`);
 
     // Verify the library files were created
     expect(
@@ -57,22 +54,22 @@ describe('Go Libraries', () => {
     ).toBeTruthy();
 
     // Reset Nx daemon to pick up new project
-    runNxCommand('reset');
+    runCLI('reset');
 
     // Run tidy
-    const tidyResults = runNxCommand(`tidy ${golib}`);
+    const tidyResults = runCLI(`tidy ${golib}`);
     expect(tidyResults).toContain(
       `NX   Successfully ran target tidy for project ${golib}`
     );
 
     // Run lint
-    const lintResults = runNxCommand(`lint ${golib}`);
+    const lintResults = runCLI(`lint ${golib}`);
     expect(lintResults).toContain(
       `NX   Successfully ran target lint for project ${golib}`
     );
 
     // Run test
-    const testResults = runNxCommand(`test ${golib}`);
+    const testResults = runCLI(`test ${golib}`);
     expect(testResults).toContain(
       `NX   Successfully ran target test for project ${golib}`
     );

--- a/packages/gonx-e2e/src/static-analysis.spec.ts
+++ b/packages/gonx-e2e/src/static-analysis.spec.ts
@@ -1,35 +1,32 @@
-import {
-  uniq,
-  tmpProjPath,
-  runNxCommand,
-  ensureNxProject,
-  cleanup,
-  readJson,
-} from '@nx/plugin/testing';
+import { uniq, tmpProjPath, readJson } from '@nx/plugin/testing';
+import { createTestProject, cleanup, runCLI } from '@naxodev/e2e-utils';
 import { join } from 'path';
 import { writeFileSync, readFileSync } from 'fs';
 
 describe('Dependency Detection', () => {
-  beforeEach(() => {
-    ensureNxProject('@naxodev/gonx', 'dist/packages/gonx');
+  beforeAll(() => {
+    // Create a real Nx workspace and install @naxodev/gonx from the local
+    // registry — exercises the published-tarball install path (peerDeps,
+    // exports) that the legacy ensureNxProject fixture never touched.
+    createTestProject('gonx');
 
     // Initialize Go support
-    runNxCommand('generate @naxodev/gonx:init');
-  });
+    runCLI('generate @naxodev/gonx:init');
+  }, 300_000);
 
-  afterEach(() => cleanup());
+  afterAll(() => cleanup());
 
   it('should detect dependencies between Go projects', async () => {
     const goapp = uniq('goapp');
     const golib = uniq('golib');
 
     // Generate a library first
-    runNxCommand(`generate @naxodev/gonx:library ${golib}`, {
+    runCLI(`generate @naxodev/gonx:library ${golib}`, {
       env: { NX_ADD_PLUGINS: 'true' },
     });
 
     // Generate an application
-    runNxCommand(`generate @naxodev/gonx:application ${goapp}`, {
+    runCLI(`generate @naxodev/gonx:application ${goapp}`, {
       env: { NX_ADD_PLUGINS: 'true' },
     });
 
@@ -68,13 +65,15 @@ replace ${libModulePath} => ../${golib}
     );
 
     // Reset Nx to pick up the changes
-    runNxCommand('reset');
+    runCLI('reset');
 
-    // Run nx graph to generate the project graph JSON
-    runNxCommand('graph --file=graph.json');
+    // Per-test graph file: the workspace is shared across tests (beforeAll), so
+    // a fixed name could let one test read a stale graph written by another.
+    const graphFile = `graph-${goapp}.json`;
+    runCLI(`graph --file=${graphFile}`);
 
     // Read the generated graph file
-    const graphJson = readJson('graph.json');
+    const graphJson = readJson(graphFile);
 
     // Verify that the dependency was detected
     const appDeps = graphJson.graph?.dependencies?.[goapp] || [];
@@ -91,15 +90,15 @@ replace ${libModulePath} => ../${golib}
     const golib2 = uniq('golib2');
 
     // Generate two libraries
-    runNxCommand(`generate @naxodev/gonx:library ${golib1}`, {
+    runCLI(`generate @naxodev/gonx:library ${golib1}`, {
       env: { NX_ADD_PLUGINS: 'true' },
     });
-    runNxCommand(`generate @naxodev/gonx:library ${golib2}`, {
+    runCLI(`generate @naxodev/gonx:library ${golib2}`, {
       env: { NX_ADD_PLUGINS: 'true' },
     });
 
     // Generate an application
-    runNxCommand(`generate @naxodev/gonx:application ${goapp}`, {
+    runCLI(`generate @naxodev/gonx:application ${goapp}`, {
       env: { NX_ADD_PLUGINS: 'true' },
     });
 
@@ -171,11 +170,12 @@ replace ${lib1ModulePath} => ../${golib1}
     );
 
     // Reset Nx
-    runNxCommand('reset');
+    runCLI('reset');
 
-    // Generate and check the graph
-    runNxCommand('graph --file=graph.json');
-    const graphJson = readJson('graph.json');
+    // Generate and check the graph (per-test file; see note above).
+    const graphFile = `graph-${goapp}.json`;
+    runCLI(`graph --file=${graphFile}`);
+    const graphJson = readJson(graphFile);
 
     // Check app -> lib1 dependency
     const appDeps = graphJson.graph?.dependencies?.[goapp] || [];

--- a/packages/nx-cloudflare-e2e/src/application.spec.ts
+++ b/packages/nx-cloudflare-e2e/src/application.spec.ts
@@ -1,30 +1,45 @@
+import { uniq, fileExists, tmpProjPath } from '@nx/plugin/testing';
 import {
-  uniq,
-  fileExists,
-  tmpProjPath,
-  runNxCommand,
-  ensureNxProject,
+  createTestProject,
   cleanup,
-} from '@nx/plugin/testing';
-import { promisifiedTreeKill, runCommandUntil } from '@naxodev/e2e-utils';
+  runCLI,
+  showProject,
+  runCommandUntil,
+  promisifiedTreeKill,
+} from '@naxodev/e2e-utils';
 import { join } from 'path';
 
 describe('Cloudflare Worker Applications', () => {
-  beforeEach(() => {
+  let priorFlatConfig: string | undefined;
+
+  beforeAll(() => {
     // Nx 22.7 defaults generated projects to ESLint flat config, whose config
     // imports `typescript-eslint`. The bare e2e workspace never installs it, so
     // force the eslintrc format used across this repo to keep `nx lint`
     // resolvable (mirrors the plugin's generator unit-test expectations).
+    // Captured/restored so the override doesn't leak into other suites in the
+    // shared jest worker.
+    priorFlatConfig = process.env.ESLINT_USE_FLAT_CONFIG;
     process.env.ESLINT_USE_FLAT_CONFIG = 'false';
-    ensureNxProject('@naxodev/nx-cloudflare', 'dist/packages/nx-cloudflare');
+    // Create a real Nx workspace and install @naxodev/nx-cloudflare from the
+    // local registry — exercises the published-tarball install path (peerDeps,
+    // exports) that the legacy ensureNxProject fixture never touched.
+    createTestProject('nx-cloudflare');
+  }, 300_000);
+
+  afterAll(() => {
+    if (priorFlatConfig === undefined) {
+      delete process.env.ESLINT_USE_FLAT_CONFIG;
+    } else {
+      process.env.ESLINT_USE_FLAT_CONFIG = priorFlatConfig;
+    }
+    cleanup();
   });
 
-  afterEach(() => cleanup());
-
-  it('should be able to generate an empty application', async () => {
+  it('should be able to generate an empty application', () => {
     const workerapp = uniq('workerapp');
 
-    runNxCommand(
+    runCLI(
       `generate @naxodev/nx-cloudflare:app --directory="apps/${workerapp}" --name=${workerapp} --template="none"`,
       { env: { NX_ADD_PLUGINS: 'true' } }
     );
@@ -32,20 +47,41 @@ describe('Cloudflare Worker Applications', () => {
     expect(
       fileExists(join(tmpProjPath(), `apps/${workerapp}/project.json`))
     ).toBeTruthy();
-  }, 30_000);
+  }, 120_000);
 
-  it('should be able to generate an fetch-handler application', async () => {
+  it('should resolve the serve and deploy executors from the installed package', () => {
     const workerapp = uniq('workerapp');
 
-    runNxCommand(
+    runCLI(
       `generate @naxodev/nx-cloudflare:app --directory="apps/${workerapp}" --name=${workerapp} --template="fetch-handler"`,
       { env: { NX_ADD_PLUGINS: 'true' } }
     );
 
-    // Reset Nx daemon to pick up new project
-    runNxCommand(`reset`);
+    // Reset the Nx daemon so the freshly generated project is in the graph.
+    runCLI('reset');
 
-    const lintResults = runNxCommand(`lint ${workerapp}`);
+    const project = showProject(workerapp);
+
+    expect(project.targets?.serve?.executor).toBe(
+      '@naxodev/nx-cloudflare:serve'
+    );
+    expect(project.targets?.deploy?.executor).toBe(
+      '@naxodev/nx-cloudflare:deploy'
+    );
+  }, 120_000);
+
+  it('should be able to generate and serve a fetch-handler application', async () => {
+    const workerapp = uniq('workerapp');
+
+    runCLI(
+      `generate @naxodev/nx-cloudflare:app --directory="apps/${workerapp}" --name=${workerapp} --template="fetch-handler"`,
+      { env: { NX_ADD_PLUGINS: 'true' } }
+    );
+
+    // Reset the Nx daemon so the freshly generated project is in the graph.
+    runCLI('reset');
+
+    const lintResults = runCLI(`lint ${workerapp}`);
     expect(lintResults).toContain(
       `NX   Successfully ran target lint for project ${workerapp}`
     );
@@ -63,18 +99,18 @@ describe('Cloudflare Worker Applications', () => {
     }
   }, 120_000);
 
-  it('should be able to generate an scheduled-handler application', async () => {
+  it('should be able to generate and serve a scheduled-handler application', async () => {
     const workerapp = uniq('workerapp');
 
-    runNxCommand(
+    runCLI(
       `generate @naxodev/nx-cloudflare:app --directory="apps/${workerapp}" --name=${workerapp} --template="scheduled-handler"`,
       { env: { NX_ADD_PLUGINS: 'true' } }
     );
 
-    // Reset Nx daemon to pick up new project
-    runNxCommand(`reset`);
+    // Reset the Nx daemon so the freshly generated project is in the graph.
+    runCLI('reset');
 
-    const lintResults = runNxCommand(`lint ${workerapp}`);
+    const lintResults = runCLI(`lint ${workerapp}`);
     expect(lintResults).toContain(
       `NX   Successfully ran target lint for project ${workerapp}`
     );
@@ -92,18 +128,18 @@ describe('Cloudflare Worker Applications', () => {
     }
   }, 120_000);
 
-  it('should be able to generate an hono application', async () => {
+  it('should be able to generate and serve a hono application', async () => {
     const workerapp = uniq('workerapp');
 
-    runNxCommand(
+    runCLI(
       `generate @naxodev/nx-cloudflare:app --directory="apps/${workerapp}" --name=${workerapp} --template="hono"`,
       { env: { NX_ADD_PLUGINS: 'true' } }
     );
 
-    // Reset Nx daemon to pick up new project
-    runNxCommand(`reset`);
+    // Reset the Nx daemon so the freshly generated project is in the graph.
+    runCLI('reset');
 
-    const lintResults = runNxCommand(`lint ${workerapp}`);
+    const lintResults = runCLI(`lint ${workerapp}`);
     expect(lintResults).toContain(
       `NX   Successfully ran target lint for project ${workerapp}`
     );
@@ -121,25 +157,28 @@ describe('Cloudflare Worker Applications', () => {
     }
   }, 120_000);
 
-  it('should be able to generate an application without specifying a directory', async () => {
+  it('should be able to generate an application without specifying a directory', () => {
     const workerapp = uniq('workerapp');
 
-    runNxCommand(
+    runCLI(
       `generate @naxodev/nx-cloudflare:app ${workerapp} --template="fetch-handler"`,
       { env: { NX_ADD_PLUGINS: 'true' } }
-    );
-
-    // Reset Nx daemon to pick up new project
-    runNxCommand(`reset`);
-
-    const lintResults = runNxCommand(`lint ${workerapp}`);
-    expect(lintResults).toContain(
-      `NX   Successfully ran target lint for project ${workerapp}`
     );
 
     // Default directory should be the app name
     expect(
       fileExists(join(tmpProjPath(), `${workerapp}/src/index.ts`))
     ).toBeTruthy();
+
+    // Reset the Nx daemon so the freshly generated project is in the graph.
+    runCLI('reset');
+
+    // The default-directory project must still resolve the installed package's
+    // executors (not just scaffold files).
+    const project = showProject(workerapp);
+    expect(project.root).toBe(workerapp);
+    expect(project.targets?.serve?.executor).toBe(
+      '@naxodev/nx-cloudflare:serve'
+    );
   }, 120_000);
 });

--- a/packages/nx-cloudflare-e2e/src/library.spec.ts
+++ b/packages/nx-cloudflare-e2e/src/library.spec.ts
@@ -1,53 +1,65 @@
+import { uniq } from '@nx/plugin/testing';
 import {
-  uniq,
-  fileExists,
-  tmpProjPath,
-  runNxCommand,
-  ensureNxProject,
+  createTestProject,
   cleanup,
-} from '@nx/plugin/testing';
-import { join } from 'path';
+  runCLI,
+  showProject,
+} from '@naxodev/e2e-utils';
 
 describe('Cloudflare Worker Library', () => {
-  beforeEach(() => {
+  let priorFlatConfig: string | undefined;
+
+  beforeAll(() => {
     // Nx 22.7 defaults generated projects to ESLint flat config, whose config
     // imports `typescript-eslint`. The bare e2e workspace never installs it, so
     // force the eslintrc format used across this repo to keep `nx lint`
     // resolvable (mirrors the plugin's generator unit-test expectations).
+    // Captured/restored so the override doesn't leak into other suites in the
+    // shared jest worker.
+    priorFlatConfig = process.env.ESLINT_USE_FLAT_CONFIG;
     process.env.ESLINT_USE_FLAT_CONFIG = 'false';
-    ensureNxProject('@naxodev/nx-cloudflare', 'dist/packages/nx-cloudflare');
+    // Create a real Nx workspace and install @naxodev/nx-cloudflare from the
+    // local registry — exercises the published-tarball install path (peerDeps,
+    // exports) that the legacy ensureNxProject fixture never touched.
+    createTestProject('nx-cloudflare');
+  }, 300_000);
+
+  afterAll(() => {
+    if (priorFlatConfig === undefined) {
+      delete process.env.ESLINT_USE_FLAT_CONFIG;
+    } else {
+      process.env.ESLINT_USE_FLAT_CONFIG = priorFlatConfig;
+    }
+    cleanup();
   });
 
-  afterEach(() => cleanup());
-
-  it('should be able to generate a library', async () => {
+  it('should be able to generate a library', () => {
     const workerlib = uniq('workerlib');
 
-    runNxCommand(
+    runCLI(
       `generate @naxodev/nx-cloudflare:lib --name=${workerlib} --directory="libs/${workerlib}" --unitTestRunner="none"`
     );
 
-    // Reset Nx daemon to pick up new project
-    runNxCommand('reset');
+    // Reset the Nx daemon so the freshly generated project is in the graph.
+    runCLI('reset');
 
-    expect(
-      fileExists(join(tmpProjPath(), `libs/${workerlib}/project.json`))
-    ).toBeTruthy();
-  }, 30_000);
+    // Assert via the project graph rather than a fixed manifest file: under
+    // Nx's TS-solution setup `@nx/js:library` emits package.json-based config,
+    // not project.json, so a file check would be format-coupled and brittle.
+    expect(showProject(workerlib).root).toBe(`libs/${workerlib}`);
+  }, 120_000);
 
-  it('should be able to generate a library without specifying a directory', async () => {
+  it('should be able to generate a library without specifying a directory', () => {
     const workerlib = uniq('workerlib');
 
-    runNxCommand(
+    runCLI(
       `generate @naxodev/nx-cloudflare:lib ${workerlib} --unitTestRunner="none"`
     );
 
-    // Reset Nx daemon to pick up new project
-    runNxCommand('reset');
+    // Reset the Nx daemon so the freshly generated project is in the graph.
+    runCLI('reset');
 
-    // Default directory should be the library name
-    expect(
-      fileExists(join(tmpProjPath(), `${workerlib}/project.json`))
-    ).toBeTruthy();
-  }, 30_000);
+    // Default directory should be the library name.
+    expect(showProject(workerlib).root).toBe(workerlib);
+  }, 120_000);
 });


### PR DESCRIPTION
Migrates **both** the `nx-cloudflare-e2e` and `gonx-e2e` suites from the legacy `ensureNxProject` fixture (which copies the built `dist` into a workspace) to `createTestProject` — creating a real Nx workspace and installing the plugin from the local Verdaccio registry. This exercises the actual published-tarball install path consumers use (peerDeps, package `exports`, executor resolution), which the old fixture never touched.

Closes #143 (also covers the equivalent gonx migration).

## Changes

- **`e2e-utils/src/lib/create-test-project.ts`** — add `createTestProject(plugin)` composing the previously-unused `newNxProject()` + `installPlugin()`. Pin the generated workspace to this repo's Nx version (not `@latest`). Harden the `create-nx-workspace` subprocess env (`CI=true`, `GIT_CEILING_DIRECTORIES`, Nx Cloud disabled).
- **`nx-cloudflare-e2e`** (2 specs) / **`gonx-e2e`** (4 specs) — `createTestProject(...)` in `beforeAll`; `runNxCommand` → `runCLI`; `beforeEach`/`afterEach` → `beforeAll`/`afterAll`. Assert via `nx show project --json` where format-agnostic. go-blueprint keeps its non-interactive (CI) skip guard.
- **`.verdaccio/config.yml`** — non-proxied `@naxodev/*` rule.
- **`nx.json`** — pin `cli.packageManager` to `pnpm`.
- **`.github/workflows/ci.yml`** — run e2e serially (`--parallel=1`) + `timeout-minutes` backstop.

## Bugs this surfaced (all invisible to `ensureNxProject`)

1. **Local-registry publish silently failing** (`409 "already present"`) — Verdaccio proxied `@naxodev/*` from npm and rejected the local publish, so the `e2e` dist-tag was never created. Fixed by the non-proxied scope rule.
2. **`create-nx-workspace` git conflict** — detects the outer repo, skips `git init`, then `git add` fails because the workspace is under the gitignored `tmp/`. Fixed with `GIT_CEILING_DIRECTORIES`.
3. **`bun: not found` on CI** — Nx PM auto-detection reached a `bun` code path during `nx-release-publish`; bun is installed locally but absent on CI runners, crashing the verdaccio task. Pinning `cli.packageManager: pnpm` removes every bun path.
4. **Parallel e2e hangs on the shared registry** — both suites share one Verdaccio; running them in parallel races on registry ownership/teardown. Because installs run through a blocking `execSync`, a registry torn down mid-run (or a teardown drain that stalls) pins jest forever (its async timeout can't fire). Fixed by running e2e serially; the `timeout-minutes` cap is a backstop.
5. **Library generator emits `package.json`-based config** under Nx's TS-solution setup, not `project.json` — the old file-existence assertion was format-coupled. Now asserted via the project graph.

## Verification

Reproduced the CI runner environment locally by **hiding `bun` from `PATH`** and running both suites the way CI now does (`nx run-many -t e2e -p nx-cloudflare-e2e gonx-e2e --parallel=1`), under a hard `timeout` to prove the process exits (no hang):
- nx-cloudflare-e2e — **8/8 pass**
- gonx-e2e — **38/38 pass** (4 suites)
- completes in ~7 min, exits cleanly; publish succeeds, no `bun: not found`, no npmjs fallback.
- `tsc --noEmit` + `eslint --quiet` + `nx format:check` clean.

Part of #115.

---

Note (out of scope, flagging for a follow-up): `ci.yml` hardcodes `runs-on: ubuntu-latest` instead of `${{ matrix.os }}`, so the `macos-latest`/`windows-latest` matrix entries actually run on ubuntu — the cross-OS coverage is currently illusory.