### PR TITLE
fix(nx-cloudflare): correct dependency classification, add exports map, drop deep @nx imports (#141, #142, #139)

### DIFF
--- a/packages/nx-cloudflare/package.json
+++ b/packages/nx-cloudflare/package.json
@@ -11,12 +11,13 @@
   "license": "MIT",
   "dependencies": {
     "tslib": "^2.3.0",
-    "wrangler": "^4.26.0",
-    "@nx/js": "^22.0.0",
-    "@nx/web": "^22.0.0",
-    "@nx/node": "^22.0.0",
     "@nx/devkit": "^22.0.0",
+    "@nx/js": "^22.0.0",
+    "@nx/node": "^22.0.0",
     "@nx/vitest": "^22.0.0"
+  },
+  "peerDependencies": {
+    "wrangler": "^4.0.0"
   },
   "keywords": [
     "nx",
@@ -38,5 +39,20 @@
   "main": "./src/index.js",
   "typings": "./src/index.d.ts",
   "executors": "./executors.json",
-  "generators": "./generators.json"
+  "generators": "./generators.json",
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "default": "./src/index.js"
+    },
+    "./package.json": "./package.json",
+    "./generators.json": "./generators.json",
+    "./executors.json": "./executors.json",
+    "./src/executors/*/executor": "./src/executors/*/executor.js",
+    "./src/executors/*/schema.json": "./src/executors/*/schema.json",
+    "./src/executors/*/schema": "./src/executors/*/schema.d.ts",
+    "./src/generators/*/generator": "./src/generators/*/generator.js",
+    "./src/generators/*/schema.json": "./src/generators/*/schema.json",
+    "./src/generators/*/schema": "./src/generators/*/schema.d.ts"
+  }
 }

--- a/packages/nx-cloudflare/src/executors/serve/executor.spec.ts
+++ b/packages/nx-cloudflare/src/executors/serve/executor.spec.ts
@@ -8,7 +8,7 @@ jest.mock('child_process', () => ({
 }));
 
 const waitForPortOpenMock = jest.fn();
-jest.mock('@nx/web/src/utils/wait-for-port-open', () => ({
+jest.mock('../../utils/wait-for-port-open', () => ({
   waitForPortOpen: (...args: unknown[]) => waitForPortOpenMock(...args),
 }));
 
@@ -68,5 +68,20 @@ describe('serve executor', () => {
     // Emitting 'error' must be handled (no throw) and reject the iteration.
     server.emit('error', new Error('spawn ENOENT'));
     await expect(next).rejects.toThrow(/wrangler|worker/i);
+  });
+
+  it('routes a port-wait failure through error() instead of rejecting uncaught', async () => {
+    const server = fakeServer();
+    spawnMock.mockReturnValue(server);
+    waitForPortOpenMock.mockRejectedValue(
+      Object.assign(new Error('refused'), { code: 'ECONNREFUSED' })
+    );
+
+    const gen = serveExecutor({ port: 8787 } as never, context());
+    // createAsyncIterable runs the listener fire-and-forget, so the rejection
+    // must reach the iteration via error(), not escape as an unhandled rejection.
+    await expect(gen.next()).rejects.toThrow(
+      /did not start listening on port 8787/i
+    );
   });
 });

--- a/packages/nx-cloudflare/src/executors/serve/executor.ts
+++ b/packages/nx-cloudflare/src/executors/serve/executor.ts
@@ -2,7 +2,7 @@ import { ExecutorContext } from '@nx/devkit';
 import { ServeSchema } from './schema';
 import { spawn } from 'child_process';
 import { createAsyncIterable } from '@nx/devkit/src/utils/async-iterable';
-import { waitForPortOpen } from '@nx/web/src/utils/wait-for-port-open';
+import { waitForPortOpen } from '../../utils/wait-for-port-open';
 import { createCliOptions } from '../../utils/create-cli-options';
 import { getProjectCwd } from '../../utils/project-paths';
 import { resolveWranglerBin } from '../../utils/wrangler';
@@ -55,7 +55,21 @@ export default async function* serveExecutor(
       process.on('SIGTERM', () => killServer());
       process.on('SIGHUP', () => killServer());
 
-      await waitForPortOpen(options.port);
+      // createAsyncIterable invokes this listener fire-and-forget, so a
+      // rejection here would surface as an unhandled rejection instead of
+      // failing the executor. Route it through error() like the spawn paths.
+      try {
+        await waitForPortOpen(options.port);
+      } catch (err) {
+        error(
+          new Error(
+            `Cloudflare worker did not start listening on port ${
+              options.port
+            }: ${err instanceof Error ? err.message : String(err)}`
+          )
+        );
+        return;
+      }
 
       next({
         success: true,

--- a/packages/nx-cloudflare/src/generators/init/generator.ts
+++ b/packages/nx-cloudflare/src/generators/init/generator.ts
@@ -5,11 +5,11 @@ import {
   Tree,
 } from '@nx/devkit';
 import { initGenerator as nodeInitGenerator } from '@nx/js';
-import { tslibVersion } from '@nx/node/src/utils/versions';
 import type { InitGeneratorSchema } from './schema';
 import {
   cloudflareWorkersTypeVersions,
   honoVersion,
+  tslibVersion,
   vitestPoolWorkersVersion,
   vitestVersion,
   wranglerVersion,

--- a/packages/nx-cloudflare/src/utils/versions.ts
+++ b/packages/nx-cloudflare/src/utils/versions.ts
@@ -1,4 +1,8 @@
 export const wranglerVersion = '^4.26.0';
+// Vendored from `@nx/node/src/utils/versions` to avoid a deep, unstable
+// `@nx/*/src/...` import. (`@nx/node` itself remains a dependency — the
+// application generator still uses its public `applicationGenerator`.)
+export const tslibVersion = '^2.3.0';
 export const cloudflareWorkersTypeVersions = '^4.20250404.0';
 export const honoVersion = '^4.8.9';
 export const vitestPoolWorkersVersion = '^0.12.0';

--- a/packages/nx-cloudflare/src/utils/wait-for-port-open.spec.ts
+++ b/packages/nx-cloudflare/src/utils/wait-for-port-open.spec.ts
@@ -1,0 +1,76 @@
+import * as net from 'net';
+import { waitForPortOpen } from './wait-for-port-open';
+
+// Exercises the real retry/connect logic against ephemeral ports — the executor
+// spec mocks this module, so this is the only place the vendored poller runs.
+describe('waitForPortOpen', () => {
+  const servers: net.Server[] = [];
+
+  function listen(port = 0): Promise<number> {
+    const server = net.createServer();
+    servers.push(server);
+    return new Promise((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(port, '127.0.0.1', () => {
+        const address = server.address();
+        resolve(typeof address === 'object' && address ? address.port : 0);
+      });
+    });
+  }
+
+  // Grab a port the OS just handed out, then release it — gives us a port
+  // that is guaranteed free (and therefore refusing connections) right now.
+  async function freePort(): Promise<number> {
+    const port = await listen();
+    await new Promise<void>((resolve) => servers.pop()?.close(() => resolve()));
+    return port;
+  }
+
+  afterEach(async () => {
+    await Promise.all(
+      servers
+        .splice(0)
+        .map(
+          (server) =>
+            new Promise<void>((resolve) => server.close(() => resolve()))
+        )
+    );
+  });
+
+  it('resolves once the port is accepting connections', async () => {
+    const port = await listen();
+    await expect(waitForPortOpen(port)).resolves.toBeUndefined();
+  });
+
+  it('retries while the port is refused, then resolves when it opens', async () => {
+    const port = await freePort();
+    const pending = waitForPortOpen(port, { retries: 50, retryDelay: 20 });
+
+    // Open the server only after the first connection attempts have been
+    // refused, forcing the retry loop to be what eventually succeeds.
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    await listen(port);
+
+    await expect(pending).resolves.toBeUndefined();
+  });
+
+  it('rejects with ECONNREFUSED after retries are exhausted', async () => {
+    const port = await freePort();
+    await expect(
+      waitForPortOpen(port, { retries: 1, retryDelay: 10 })
+    ).rejects.toMatchObject({ code: 'ECONNREFUSED' });
+  });
+
+  it('rejects immediately on a non-retryable error code', async () => {
+    // `.invalid` never resolves (RFC 2606) → ENOTFOUND, which is not in the
+    // allowed list. The huge retryDelay means this can only pass if the error
+    // short-circuits the retry loop instead of waiting it out.
+    await expect(
+      waitForPortOpen(1234, {
+        host: 'host.invalid',
+        retries: 100,
+        retryDelay: 5000,
+      })
+    ).rejects.toMatchObject({ code: 'ENOTFOUND' });
+  });
+});

--- a/packages/nx-cloudflare/src/utils/wait-for-port-open.ts
+++ b/packages/nx-cloudflare/src/utils/wait-for-port-open.ts
@@ -1,0 +1,62 @@
+import { logger } from '@nx/devkit';
+import * as net from 'net';
+
+interface WaitForPortOpenOptions {
+  host?: string;
+  retries?: number;
+  retryDelay?: number;
+}
+
+// Vendored from `@nx/web/src/utils/wait-for-port-open` to avoid a deep,
+// unstable `@nx/*/src/...` import (and the `@nx/web` dependency it required).
+// Polls a TCP port until something accepts a connection — used to detect when
+// `wrangler dev` is ready to serve.
+export function waitForPortOpen(
+  port: number,
+  options: WaitForPortOpenOptions = {}
+): Promise<void> {
+  // Default to the IPv4 loopback: Node may resolve "localhost" to IPv6 ("::1"),
+  // which fails if the server only listens on IPv4 (as `wrangler dev` does).
+  // Callers can override via `options.host`.
+  const host = options.host ?? '127.0.0.1';
+  const allowedErrorCodes = ['ECONNREFUSED', 'ECONNRESET', 'ETIMEDOUT'];
+
+  return new Promise((resolve, reject) => {
+    const checkPort = (retries = options.retries ?? 120) => {
+      const client = new net.Socket();
+      const cleanupClient = () => {
+        client.removeAllListeners('connect');
+        client.removeAllListeners('error');
+        client.end();
+        client.destroy();
+        client.unref();
+      };
+
+      client.once('connect', () => {
+        cleanupClient();
+        resolve();
+      });
+
+      client.once('error', (err: NodeJS.ErrnoException) => {
+        if (retries === 0 || !allowedErrorCodes.includes(err.code ?? '')) {
+          if (process.env['NX_VERBOSE_LOGGING'] === 'true') {
+            logger.info(
+              `Error connecting on ${host}:${port}: ${err.code || err}`
+            );
+          }
+          cleanupClient();
+          reject(err);
+        } else {
+          setTimeout(() => checkPort(retries - 1), options.retryDelay ?? 1000);
+        }
+      });
+
+      if (process.env['NX_VERBOSE_LOGGING'] === 'true') {
+        logger.info(`Connecting on ${host}:${port}`);
+      }
+      client.connect({ port, host });
+    };
+
+    checkPort();
+  });
+}


### PR DESCRIPTION
## TL;DR

Corrects the published-package shape after the Next.js drop: `@nx/*` stay in `dependencies` (matching every official Nx plugin — see below), `wrangler` becomes a `peerDependencies` (the `@nx/vite`→`vite` pattern), an `exports` map is added, and the two deep `@nx/*/src/...` imports that were cheap to remove are vendored — which also drops the `@nx/web` dependency.

**Files to review (7, +192 / -8):**

| File | Why |
|---|---|
| `packages/nx-cloudflare/package.json` *(start here)* | Dep reclassification + `exports` map. |
| `src/utils/wait-for-port-open.ts` *(new)* | Vendored from `@nx/web` (drops the dep). |
| `src/utils/wait-for-port-open.spec.ts` *(new)* | Direct coverage for the vendored poller (real `net.Server`). |
| `src/utils/versions.ts` | `tslibVersion` now local (drops the `@nx/node/src` deep import). |
| `src/executors/serve/executor.ts` + `executor.spec.ts` | Use the vendored `waitForPortOpen`; route a port-wait failure through `error()`. |
| `src/generators/init/generator.ts` | `tslibVersion` from local `versions.ts`. |

## Why

`@nx/dependency-checks` and the Next.js drop exposed three packaging issues (#141, #142, #139). The headline one — #141 — proposed moving `@nx/*` to `peerDependencies`. Checking how Nx actually ships shows that's backwards:

| Plugin | `@nx/*` + tslib | peerDependencies |
|---|---|---|
| @nx/react, @nx/node, @nx/js, @nx/jest, @nx/plugin | `dependencies` | — |
| @nx/vite | `dependencies` | `vite`, `vitest` |
| @nx/esbuild | `dependencies` | `esbuild` |

Every official plugin keeps the `@nx/*` toolchain in `dependencies`; `peerDependencies` is for the **third-party tool the plugin drives**. (Full evidence on #141.)

## How

- **#141** — `@nx/*` stay in `dependencies` at `^22.0.0` (a range, not the exact pin official plugins use, because this plugin releases independently of Nx — the caret dedupes against the consumer's Nx 22.x). `wrangler` → `peerDependencies` (`^4.0.0`); the `init` generator already installs it into the consumer workspace, satisfying the peer.
- **#142** — `exports` map modeled on `@nx/vite`, including the executor/generator subpaths Nx resolves. `./plugin` and `./migrations.json` are deferred until the files exist (#136 / #138).
- **#139** — vendored `waitForPortOpen` (drops `@nx/web`) and moved `tslibVersion` local (drops the `@nx/node/src` deep import). Final deps: `tslib, @nx/devkit, @nx/js, @nx/node, @nx/vitest`.

## Reviewer notes

- **#139 scoped down deliberately.** No public API exists in Nx 22.7.5 for `determineProjectNameAndRootOptions`, the `ts-solution-setup` helpers, `getImportPath`, etc. — vendoring those means copying large Nx internals that will drift, worse than the deep-import risk. Only the two tiny/stable helpers that also remove a dependency were vendored; the rest are left for when Nx exposes public APIs or the generators are reworked (#137/#140).
- **`wrangler` as a peer is verified.** `require.resolve('wrangler/...')` satisfies `@nx/dependency-checks`, and the e2e (which runs `serve` from the installed tarball) confirms `init` provides it.
- **`@nx/node` stays** — the application generator still uses its public `applicationGenerator`; only its deep `tslibVersion` import was removed.

## Reviewer notes

- **Port-wait failures now surface.** `createAsyncIterable` runs the serve executor's listener fire-and-forget, so an `await waitForPortOpen()` rejection previously escaped as an unhandled rejection (silent hang / opaque crash) rather than failing the task. It's now wrapped and routed through `error()`, matching the existing `spawn` error paths. Pre-existing, fixed here since the PR reworks this module.
- **Vendored poller is now tested.** `wait-for-port-open.spec.ts` exercises the real retry/connect logic against ephemeral ports (resolve on connect, retry-then-resolve, reject after retries, immediate reject on a non-retryable code) — the executor spec mocks the module, so this is its only direct coverage.

## Tests

- `nx lint nx-cloudflare` (incl. `@nx/dependency-checks`) + `build` + `test` (10 suites / 100) green; `nx format:check` clean.
- `nx e2e nx-cloudflare-e2e` — **8/8**, validating the `exports` map does not break Nx's generator/executor resolution from the installed tarball and that the `wrangler` peer is satisfied.
- `pnpm install --frozen-lockfile` in sync.

## Links

- Closes #141, #142, #139
- Part of #115
