### PR TITLE
feat(nx-cloudflare)!: bump scaffolded deps to latest and migrate vitest config to v4

### DIFF
--- a/packages/nx-cloudflare/src/generators/application/files/common/vitest.config.ts__tmpl__
+++ b/packages/nx-cloudflare/src/generators/application/files/common/vitest.config.ts__tmpl__
@@ -1,11 +1,10 @@
-import { defineWorkersConfig } from '@cloudflare/vitest-pool-workers/config';
+import { cloudflareTest } from '@cloudflare/vitest-pool-workers';
+import { defineConfig } from 'vitest/config';
 
-export default defineWorkersConfig({
-  test: {
-    poolOptions: {
-      workers: {
-        wrangler: { configPath: './<%= configFileName %>' },
-      },
-    },
-  },
+export default defineConfig({
+  plugins: [
+    cloudflareTest({
+      wrangler: { configPath: './<%= configFileName %>' },
+    }),
+  ],
 });

--- a/packages/nx-cloudflare/src/generators/application/generator.spec.ts
+++ b/packages/nx-cloudflare/src/generators/application/generator.spec.ts
@@ -337,16 +337,15 @@ describe('app', () => {
       });
       expect(tree.read('myWorkerApp/vitest.config.ts', 'utf-8'))
         .toMatchInlineSnapshot(`
-        "import { defineWorkersConfig } from '@cloudflare/vitest-pool-workers/config';
+        "import { cloudflareTest } from '@cloudflare/vitest-pool-workers';
+        import { defineConfig } from 'vitest/config';
 
-        export default defineWorkersConfig({
-          test: {
-            poolOptions: {
-              workers: {
-                wrangler: { configPath: './wrangler.jsonc' },
-              },
-            },
-          },
+        export default defineConfig({
+          plugins: [
+            cloudflareTest({
+              wrangler: { configPath: './wrangler.jsonc' },
+            }),
+          ],
         });
         "
       `);

--- a/packages/nx-cloudflare/src/utils/versions.ts
+++ b/packages/nx-cloudflare/src/utils/versions.ts
@@ -1,9 +1,9 @@
-export const wranglerVersion = '^4.26.0';
+export const wranglerVersion = '^4.98.0';
 // Vendored from `@nx/node/src/utils/versions` to avoid a deep, unstable
 // `@nx/*/src/...` import. (`@nx/node` itself remains a dependency — the
 // application generator still uses its public `applicationGenerator`.)
 export const tslibVersion = '^2.3.0';
-export const cloudflareWorkersTypeVersions = '^4.20250404.0';
-export const honoVersion = '^4.8.9';
-export const vitestPoolWorkersVersion = '^0.12.0';
-export const vitestVersion = '^3.2.4';
+export const cloudflareWorkersTypeVersions = '^4.20260606.1';
+export const honoVersion = '^4.12.23';
+export const vitestPoolWorkersVersion = '^0.16.0';
+export const vitestVersion = '^4.1.0';


### PR DESCRIPTION
## TL;DR

The init generator scaffolds worker projects with stale toolchain versions — `vitest ^3.2.4`, `@cloudflare/vitest-pool-workers ^0.12.0`, `wrangler ^4.26.0`. This bumps all five scaffolded dependencies to latest, which drags `vitest` across a major (3 → 4) and `pool-workers` to 0.16 — a release that **removed** the `@cloudflare/vitest-pool-workers/config` subpath the generated `vitest.config.ts` imported, so the config template is migrated to the new `cloudflareTest` plugin API.

**Files to review (3, +24 / -24):**

| File | Why |
|---|---|
| `packages/nx-cloudflare/src/utils/versions.ts` *(start here)* | The five version constants injected as devDependencies by `init`. |
| `.../application/files/common/vitest.config.ts__tmpl__` | Generated vitest config migrated from `defineWorkersConfig` to the `cloudflareTest` plugin. |
| `.../application/generator.spec.ts` | Inline snapshot updated to the new config output. |

## Why

`vitest@^3.2.4` and `@cloudflare/vitest-pool-workers@^0.12.0` are version-locked by peer deps — `0.12` peers `vitest 2.0.x - 3.2.x`, while latest `0.16` peers `vitest ^4.1.0`. They can't be bumped independently. Moving to latest means a coordinated vitest 3 → 4 major in every newly-generated project.

Pool-workers 0.16 didn't just bump — it reshaped its config API:

| | Before (v3 / pool-workers 0.12) | After (v4 / pool-workers 0.16) |
|---|---|---|
| Config factory | `defineWorkersConfig` from `@cloudflare/vitest-pool-workers/config` | `defineConfig` from `vitest/config` |
| Pool wiring | `test.poolOptions.workers` | `cloudflareTest(...)` plugin from package main |
| `/config` subpath | exported | **removed** — old import throws `Missing "./config" specifier` |

A version-only bump would have shipped a generated `vitest.config.ts` that fails at startup.

## How

1. Bump the three uncoupled deps to latest (`wrangler ^4.98.0`, `@cloudflare/workers-types ^4.20260606.1`, `hono ^4.12.23`) — same-major, no API change.
2. Bump the coupled pair together (`vitest ^4.1.0`, `@cloudflare/vitest-pool-workers ^0.16.0`).
3. Migrate the generated `vitest.config.ts` template to the v4 plugin shape:

```ts
import { cloudflareTest } from '@cloudflare/vitest-pool-workers';
import { defineConfig } from 'vitest/config';

export default defineConfig({
  plugins: [
    cloudflareTest({
      wrangler: { configPath: './<%= configFileName %>' },
    }),
  ],
});
```

This matches Cloudflare's [canonical v4 config](https://developers.cloudflare.com/workers/testing/vitest-integration/configuration/) — `test` is omitted when empty, mirroring the official docs example and the `workers-sdk` pool-workers fixtures.

## Reviewer notes

- **Generated config matches Cloudflare's canonical output.** The shape mirrors pool-workers' own `vitest-v3-to-v4` codemod (`defineWorkersConfig` → `defineConfig`, `poolOptions.workers` → a `cloudflareTest` plugin) and the official docs/fixture examples — including omitting `test` when empty. Not an invented migration.
- **Breaking for regeneration only.** Existing generated projects are untouched; the change affects output of future `init`/`application` runs. Users who regenerate get vitest 4 and the new config.
- **wrangler bump self-consistent.** pool-workers 0.16.13 bundles `wrangler@4.98.0` — exactly the version this PR pins, so no transitive conflict.

## Tests

- **Unit:** 101 tests / 15 snapshots pass. The `vitest.config.ts` inline snapshot in `generator.spec.ts` is updated to the new output; the toml-configPath assertion still holds.
- **E2e:** `nx-cloudflare-e2e` (Verdaccio publish → install → generate → serve) passes 8/8 — confirms vitest 4 + pool-workers 0.16 + wrangler 4.98 resolve and install cleanly together.
- **Runtime (manual):** an isolated worker project replicating the generated files (worker + `cloudflare:test` unit & integration tests + new config) runs green under `vitest@4.1.8` — `2 passed`. This surfaced the removed `/config` subpath that the version bump alone would have shipped broken; the e2e suite generates and serves apps but never runs a generated app's tests.

## Follow-up

The e2e gap is worth closing: add a "generate app → run its vitest tests" case to `nx-cloudflare-e2e` so future vitest/pool-workers bumps are caught in CI rather than by hand.
