### PR TITLE
feat(nx-cloudflare): add createNodesV2 inference plugin (#136)

### DIFF
--- a/packages/nx-cloudflare/package.json
+++ b/packages/nx-cloudflare/package.json
@@ -45,6 +45,10 @@
       "types": "./src/index.d.ts",
       "default": "./src/index.js"
     },
+    "./plugin": {
+      "types": "./src/plugin.d.ts",
+      "default": "./src/plugin.js"
+    },
     "./package.json": "./package.json",
     "./generators.json": "./generators.json",
     "./executors.json": "./executors.json",

--- a/packages/nx-cloudflare/src/plugin.spec.ts
+++ b/packages/nx-cloudflare/src/plugin.spec.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import type { CreateNodesContextV2 } from '@nx/devkit';
+import { logger, type CreateNodesContextV2 } from '@nx/devkit';
 import { createNodesV2, type CloudflarePluginOptions } from './plugin';
 
 const [configGlob, createNodesFn] = createNodesV2;
@@ -11,7 +11,11 @@ function setupWorkspace(): string {
   return mkdtempSync(join(tmpdir(), 'nx-cf-'));
 }
 
-function writeFile(workspaceRoot: string, relPath: string, content: string): void {
+function writeFile(
+  workspaceRoot: string,
+  relPath: string,
+  content: string
+): void {
   const abs = join(workspaceRoot, relPath);
   mkdirSync(join(abs, '..'), { recursive: true });
   writeFileSync(abs, content);
@@ -30,7 +34,11 @@ async function run(
   configFile: string,
   options: CloudflarePluginOptions = {}
 ) {
-  const results = await createNodesFn([configFile], options, ctx(workspaceRoot));
+  const results = await createNodesFn(
+    [configFile],
+    options,
+    ctx(workspaceRoot)
+  );
   return results[0][1];
 }
 
@@ -108,7 +116,10 @@ describe('nx-cloudflare createNodesV2', () => {
     expect(Object.keys(targets).sort()).toEqual(
       ['dev', 'logs', 'publish', 'types', 'upload'].sort()
     );
-    expect(targets.dev).toMatchObject({ command: 'wrangler dev', continuous: true });
+    expect(targets.dev).toMatchObject({
+      command: 'wrangler dev',
+      continuous: true,
+    });
   });
 
   it('returns no targets when no project.json/package.json sits beside the config', async () => {
@@ -128,6 +139,45 @@ describe('nx-cloudflare createNodesV2', () => {
 
     expect(result.projects['apps/pkg'].targets.deploy).toMatchObject({
       command: 'wrangler deploy',
+    });
+  });
+
+  it('skips an unparseable jsonc config and warns', async () => {
+    const warn = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    writeFile(workspaceRoot, 'apps/bad/project.json', '{"name":"bad"}');
+    writeFile(workspaceRoot, 'apps/bad/wrangler.jsonc', '{ not valid json ');
+
+    const result = await run(workspaceRoot, 'apps/bad/wrangler.jsonc');
+
+    expect(result).toEqual({});
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('skips an empty toml config and warns', async () => {
+    const warn = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    writeFile(workspaceRoot, 'apps/empty/project.json', '{"name":"empty"}');
+    writeFile(workspaceRoot, 'apps/empty/wrangler.toml', '   \n  ');
+
+    const result = await run(workspaceRoot, 'apps/empty/wrangler.toml');
+
+    expect(result).toEqual({});
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('accepts a non-empty toml config (no strict parse)', async () => {
+    writeFile(workspaceRoot, 'apps/tomlworker/project.json', '{"name":"tw"}');
+    writeFile(
+      workspaceRoot,
+      'apps/tomlworker/wrangler.toml',
+      'name = "tw"\nmain = "src/index.ts"\n'
+    );
+
+    const result = await run(workspaceRoot, 'apps/tomlworker/wrangler.toml');
+
+    expect(result.projects['apps/tomlworker'].targets.serve).toMatchObject({
+      command: 'wrangler dev',
     });
   });
 });

--- a/packages/nx-cloudflare/src/plugin.spec.ts
+++ b/packages/nx-cloudflare/src/plugin.spec.ts
@@ -1,0 +1,113 @@
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { CreateNodesContextV2 } from '@nx/devkit';
+import { createNodesV2, type CloudflarePluginOptions } from './plugin';
+
+const [configGlob, createNodesFn] = createNodesV2;
+
+/** Build a workspace temp dir; caller writes fixtures into it. */
+function setupWorkspace(): string {
+  return mkdtempSync(join(tmpdir(), 'nx-cf-'));
+}
+
+function writeFile(workspaceRoot: string, relPath: string, content: string): void {
+  const abs = join(workspaceRoot, relPath);
+  mkdirSync(join(abs, '..'), { recursive: true });
+  writeFileSync(abs, content);
+}
+
+function ctx(workspaceRoot: string): CreateNodesContextV2 {
+  return {
+    workspaceRoot,
+    nxJsonConfiguration: {},
+  } as unknown as CreateNodesContextV2;
+}
+
+/** Run the plugin for one config file and return the per-file result object. */
+async function run(
+  workspaceRoot: string,
+  configFile: string,
+  options: CloudflarePluginOptions = {}
+) {
+  const results = await createNodesFn([configFile], options, ctx(workspaceRoot));
+  return results[0][1];
+}
+
+describe('nx-cloudflare createNodesV2', () => {
+  let workspaceRoot: string;
+
+  beforeEach(() => {
+    workspaceRoot = setupWorkspace();
+  });
+
+  afterEach(() => {
+    rmSync(workspaceRoot, { recursive: true, force: true });
+  });
+
+  it('matches wrangler configs by extension', () => {
+    expect(configGlob).toBe('**/wrangler.{toml,jsonc,json}');
+  });
+
+  it('infers the five Worker targets for a valid jsonc config', async () => {
+    writeFile(workspaceRoot, 'apps/worker/project.json', '{"name":"worker"}');
+    writeFile(
+      workspaceRoot,
+      'apps/worker/wrangler.jsonc',
+      '{\n  // a worker\n  "name": "worker",\n  "main": "src/index.ts"\n}'
+    );
+
+    const result = await run(workspaceRoot, 'apps/worker/wrangler.jsonc');
+    const targets = result.projects['apps/worker'].targets;
+
+    expect(Object.keys(targets).sort()).toEqual(
+      ['deploy', 'serve', 'tail', 'typegen', 'version-upload'].sort()
+    );
+
+    // Why: serve is the local dev server and must stay alive across the run.
+    expect(targets.serve).toMatchObject({
+      command: 'wrangler dev',
+      options: { cwd: 'apps/worker' },
+      continuous: true,
+    });
+    // Why: tail streams logs indefinitely, so it is also continuous.
+    expect(targets.tail).toMatchObject({
+      command: 'wrangler tail',
+      options: { cwd: 'apps/worker' },
+      continuous: true,
+    });
+    // Why: deploy and version-upload have remote side effects -> never cached.
+    expect(targets.deploy).toMatchObject({ command: 'wrangler deploy' });
+    expect(targets.deploy.cache).toBeUndefined();
+    expect(targets['version-upload']).toMatchObject({
+      command: 'wrangler versions upload',
+    });
+    expect(targets['version-upload'].cache).toBeUndefined();
+    // Why: typegen is deterministic -> cacheable, invalidated on wrangler bumps.
+    expect(targets.typegen).toMatchObject({
+      command: 'wrangler types',
+      cache: true,
+      inputs: ['default', '^default', { externalDependencies: ['wrangler'] }],
+      outputs: ['{projectRoot}/worker-configuration.d.ts'],
+    });
+  });
+
+  it('honors custom target names from plugin options', async () => {
+    writeFile(workspaceRoot, 'apps/worker/project.json', '{"name":"worker"}');
+    writeFile(workspaceRoot, 'apps/worker/wrangler.jsonc', '{"name":"worker"}');
+
+    const result = await run(workspaceRoot, 'apps/worker/wrangler.jsonc', {
+      serveTargetName: 'dev',
+      deployTargetName: 'publish',
+      typegenTargetName: 'types',
+      versionUploadTargetName: 'upload',
+      tailTargetName: 'logs',
+    });
+    const targets = result.projects['apps/worker'].targets;
+
+    expect(Object.keys(targets).sort()).toEqual(
+      ['dev', 'logs', 'publish', 'types', 'upload'].sort()
+    );
+    expect(targets.dev).toMatchObject({ command: 'wrangler dev', continuous: true });
+  });
+});

--- a/packages/nx-cloudflare/src/plugin.spec.ts
+++ b/packages/nx-cloudflare/src/plugin.spec.ts
@@ -53,11 +53,10 @@ describe('nx-cloudflare createNodesV2', () => {
     rmSync(workspaceRoot, { recursive: true, force: true });
   });
 
-  it('matches wrangler configs by extension', () => {
-    expect(configGlob).toBe('**/wrangler.{toml,jsonc,json}');
-  });
-
   it('infers the five Worker targets for a valid jsonc config', async () => {
+    // The exported glob is the contract Nx uses to discover configs.
+    expect(configGlob).toBe('**/wrangler.{toml,jsonc,json}');
+
     writeFile(workspaceRoot, 'apps/worker/project.json', '{"name":"worker"}');
     writeFile(
       workspaceRoot,
@@ -150,7 +149,7 @@ describe('nx-cloudflare createNodesV2', () => {
     const result = await run(workspaceRoot, 'apps/bad/wrangler.jsonc');
 
     expect(result).toEqual({});
-    expect(warn).toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('unparseable'));
     warn.mockRestore();
   });
 
@@ -162,7 +161,7 @@ describe('nx-cloudflare createNodesV2', () => {
     const result = await run(workspaceRoot, 'apps/empty/wrangler.toml');
 
     expect(result).toEqual({});
-    expect(warn).toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('empty'));
     warn.mockRestore();
   });
 
@@ -189,7 +188,9 @@ describe('nx-cloudflare createNodesV2', () => {
     const result = await run(workspaceRoot, 'apps/ghost/wrangler.jsonc');
 
     expect(result).toEqual({});
-    expect(warn).toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('project directory')
+    );
     warn.mockRestore();
   });
 
@@ -204,5 +205,75 @@ describe('nx-cloudflare createNodesV2', () => {
     expect(second.projects['apps/worker'].targets.typegen).toMatchObject({
       cache: true,
     });
+  });
+
+  it('infers targets for a plain wrangler.json (non-jsonc) config', async () => {
+    // The glob matches `.json` too; it takes the same parse path as `.jsonc`.
+    writeFile(workspaceRoot, 'apps/jsonworker/project.json', '{"name":"jw"}');
+    writeFile(workspaceRoot, 'apps/jsonworker/wrangler.json', '{"name":"jw"}');
+
+    const result = await run(workspaceRoot, 'apps/jsonworker/wrangler.json');
+
+    expect(result.projects['apps/jsonworker'].targets.deploy).toMatchObject({
+      command: 'wrangler deploy',
+    });
+  });
+
+  it('accepts a parseable but minimal ({}) jsonc config', async () => {
+    // Why: the gate is structural, not semantic. An empty object parses, so
+    // targets are inferred; Wrangler validates the real config at runtime.
+    // (Contrast empty .toml, which is rejected — see the empty-toml test.)
+    writeFile(workspaceRoot, 'apps/min/project.json', '{"name":"min"}');
+    writeFile(workspaceRoot, 'apps/min/wrangler.jsonc', '{}');
+
+    const result = await run(workspaceRoot, 'apps/min/wrangler.jsonc');
+
+    expect(result.projects['apps/min'].targets.deploy).toMatchObject({
+      command: 'wrangler deploy',
+    });
+  });
+
+  it('reflects plugin options in cached targets, not just config content', async () => {
+    // Why: same config content, different options. If the cache keyed on
+    // content alone, the second run would be served the first run's
+    // default-named targets. Guards the options->cache-path keying.
+    writeFile(workspaceRoot, 'apps/worker/project.json', '{"name":"worker"}');
+    writeFile(workspaceRoot, 'apps/worker/wrangler.jsonc', '{"name":"worker"}');
+
+    const defaults = await run(workspaceRoot, 'apps/worker/wrangler.jsonc');
+    const custom = await run(workspaceRoot, 'apps/worker/wrangler.jsonc', {
+      serveTargetName: 'dev',
+    });
+
+    expect(Object.keys(defaults.projects['apps/worker'].targets)).toContain(
+      'serve'
+    );
+    const customTargets = custom.projects['apps/worker'].targets;
+    expect(Object.keys(customTargets)).toContain('dev');
+    expect(Object.keys(customTargets)).not.toContain('serve');
+  });
+
+  it('handles multiple configs in one invocation, isolating failures', async () => {
+    // Why: the real entry point receives many files sharing one cache. A bad
+    // config must degrade to {} without taking down a valid sibling.
+    const warn = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    writeFile(workspaceRoot, 'apps/a/project.json', '{"name":"a"}');
+    writeFile(workspaceRoot, 'apps/a/wrangler.jsonc', '{"name":"a"}');
+    writeFile(workspaceRoot, 'apps/b/project.json', '{"name":"b"}');
+    writeFile(workspaceRoot, 'apps/b/wrangler.jsonc', '{ invalid ');
+
+    const results = await createNodesFn(
+      ['apps/a/wrangler.jsonc', 'apps/b/wrangler.jsonc'],
+      {},
+      ctx(workspaceRoot)
+    );
+    const byFile = Object.fromEntries(results);
+
+    expect(
+      byFile['apps/a/wrangler.jsonc'].projects['apps/a'].targets.deploy
+    ).toMatchObject({ command: 'wrangler deploy' });
+    expect(byFile['apps/b/wrangler.jsonc']).toEqual({});
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('unparseable'));
+    warn.mockRestore();
   });
 });

--- a/packages/nx-cloudflare/src/plugin.spec.ts
+++ b/packages/nx-cloudflare/src/plugin.spec.ts
@@ -181,6 +181,18 @@ describe('nx-cloudflare createNodesV2', () => {
     });
   });
 
+  it('skips a config whose project directory cannot be read and warns', async () => {
+    const warn = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    // No directory is created for apps/ghost, so the project-marker readdir
+    // throws ENOENT. Inference must degrade to {} for this one config rather
+    // than aborting graph construction for the whole workspace.
+    const result = await run(workspaceRoot, 'apps/ghost/wrangler.jsonc');
+
+    expect(result).toEqual({});
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
   it('returns identical targets across repeated runs (cache safe)', async () => {
     writeFile(workspaceRoot, 'apps/worker/project.json', '{"name":"worker"}');
     writeFile(workspaceRoot, 'apps/worker/wrangler.jsonc', '{"name":"worker"}');

--- a/packages/nx-cloudflare/src/plugin.spec.ts
+++ b/packages/nx-cloudflare/src/plugin.spec.ts
@@ -110,4 +110,24 @@ describe('nx-cloudflare createNodesV2', () => {
     );
     expect(targets.dev).toMatchObject({ command: 'wrangler dev', continuous: true });
   });
+
+  it('returns no targets when no project.json/package.json sits beside the config', async () => {
+    // Config present, but the directory has no Nx project marker.
+    writeFile(workspaceRoot, 'apps/loose/wrangler.jsonc', '{"name":"loose"}');
+
+    const result = await run(workspaceRoot, 'apps/loose/wrangler.jsonc');
+
+    expect(result).toEqual({});
+  });
+
+  it('accepts a package.json as the project marker', async () => {
+    writeFile(workspaceRoot, 'apps/pkg/package.json', '{"name":"pkg"}');
+    writeFile(workspaceRoot, 'apps/pkg/wrangler.jsonc', '{"name":"pkg"}');
+
+    const result = await run(workspaceRoot, 'apps/pkg/wrangler.jsonc');
+
+    expect(result.projects['apps/pkg'].targets.deploy).toMatchObject({
+      command: 'wrangler deploy',
+    });
+  });
 });

--- a/packages/nx-cloudflare/src/plugin.spec.ts
+++ b/packages/nx-cloudflare/src/plugin.spec.ts
@@ -180,4 +180,17 @@ describe('nx-cloudflare createNodesV2', () => {
       command: 'wrangler dev',
     });
   });
+
+  it('returns identical targets across repeated runs (cache safe)', async () => {
+    writeFile(workspaceRoot, 'apps/worker/project.json', '{"name":"worker"}');
+    writeFile(workspaceRoot, 'apps/worker/wrangler.jsonc', '{"name":"worker"}');
+
+    const first = await run(workspaceRoot, 'apps/worker/wrangler.jsonc');
+    const second = await run(workspaceRoot, 'apps/worker/wrangler.jsonc');
+
+    expect(second).toEqual(first);
+    expect(second.projects['apps/worker'].targets.typegen).toMatchObject({
+      cache: true,
+    });
+  });
 });

--- a/packages/nx-cloudflare/src/plugin.ts
+++ b/packages/nx-cloudflare/src/plugin.ts
@@ -1,0 +1,88 @@
+import { dirname } from 'node:path';
+import {
+  type CreateNodesContextV2,
+  type CreateNodesV2,
+  type TargetConfiguration,
+  createNodesFromFiles,
+} from '@nx/devkit';
+
+/** Options to rename the inferred Cloudflare Worker targets. */
+export interface CloudflarePluginOptions {
+  serveTargetName?: string;
+  deployTargetName?: string;
+  typegenTargetName?: string;
+  versionUploadTargetName?: string;
+  tailTargetName?: string;
+}
+
+interface NormalizedOptions {
+  serveTargetName: string;
+  deployTargetName: string;
+  typegenTargetName: string;
+  versionUploadTargetName: string;
+  tailTargetName: string;
+}
+
+function normalizeOptions(
+  options: CloudflarePluginOptions | undefined
+): NormalizedOptions {
+  return {
+    serveTargetName: options?.serveTargetName ?? 'serve',
+    deployTargetName: options?.deployTargetName ?? 'deploy',
+    typegenTargetName: options?.typegenTargetName ?? 'typegen',
+    versionUploadTargetName: options?.versionUploadTargetName ?? 'version-upload',
+    tailTargetName: options?.tailTargetName ?? 'tail',
+  };
+}
+
+/**
+ * Build the Wrangler lifecycle targets for a project. Each target shells out to
+ * the Wrangler CLI via `nx:run-commands` (the `command` shorthand), run from the
+ * project root so Wrangler resolves its own config.
+ */
+function buildWorkerTargets(
+  projectRoot: string,
+  options: NormalizedOptions
+): Record<string, TargetConfiguration> {
+  const run = (
+    command: string,
+    extra: Partial<TargetConfiguration> = {}
+  ): TargetConfiguration => ({
+    command,
+    options: { cwd: projectRoot },
+    ...extra,
+  });
+
+  return {
+    [options.serveTargetName]: run('wrangler dev', { continuous: true }),
+    [options.deployTargetName]: run('wrangler deploy'),
+    [options.typegenTargetName]: run('wrangler types', {
+      cache: true,
+      inputs: ['default', '^default', { externalDependencies: ['wrangler'] }],
+      outputs: ['{projectRoot}/worker-configuration.d.ts'],
+    }),
+    [options.versionUploadTargetName]: run('wrangler versions upload'),
+    [options.tailTargetName]: run('wrangler tail', { continuous: true }),
+  };
+}
+
+function createNodesInternal(
+  configFile: string,
+  options: CloudflarePluginOptions | undefined,
+  _context: CreateNodesContextV2
+) {
+  const projectRoot = dirname(configFile);
+  const targets = buildWorkerTargets(projectRoot, normalizeOptions(options));
+  return { projects: { [projectRoot]: { targets } } };
+}
+
+export const createNodesV2: CreateNodesV2<CloudflarePluginOptions> = [
+  '**/wrangler.{toml,jsonc,json}',
+  (configFiles, options, context) =>
+    createNodesFromFiles(
+      (configFile, opts, ctx) => createNodesInternal(configFile, opts, ctx),
+      configFiles,
+      options,
+      context
+    ),
+];

--- a/packages/nx-cloudflare/src/plugin.ts
+++ b/packages/nx-cloudflare/src/plugin.ts
@@ -134,7 +134,15 @@ function createNodesInternal(
 
   // Only infer targets for real Nx projects: a sibling project.json or
   // package.json. Otherwise this wrangler file is not a project root.
-  const siblings = readdirSync(join(context.workspaceRoot, projectRoot));
+  let siblings: string[];
+  try {
+    siblings = readdirSync(join(context.workspaceRoot, projectRoot));
+  } catch (e) {
+    logger.warn(
+      `[nx-cloudflare] Could not read project directory ${projectRoot}: ${e}`
+    );
+    return {};
+  }
   if (
     !siblings.includes('project.json') &&
     !siblings.includes('package.json')

--- a/packages/nx-cloudflare/src/plugin.ts
+++ b/packages/nx-cloudflare/src/plugin.ts
@@ -15,19 +15,27 @@ import {
 
 /** Options to rename the inferred Cloudflare Worker targets. */
 export interface CloudflarePluginOptions {
+  /** Name for the inferred `wrangler dev` target. @default 'serve' */
   serveTargetName?: string;
+  /** Name for the inferred `wrangler deploy` target. @default 'deploy' */
   deployTargetName?: string;
+  /** Name for the inferred `wrangler types` target. @default 'typegen' */
   typegenTargetName?: string;
+  /**
+   * Name for the inferred `wrangler versions upload` target.
+   * @default 'version-upload'
+   */
   versionUploadTargetName?: string;
+  /** Name for the inferred `wrangler tail` target. @default 'tail' */
   tailTargetName?: string;
 }
 
-interface NormalizedOptions {
-  serveTargetName: string;
-  deployTargetName: string;
-  typegenTargetName: string;
-  versionUploadTargetName: string;
-  tailTargetName: string;
+/** {@link CloudflarePluginOptions} with every default applied. */
+type NormalizedOptions = Required<CloudflarePluginOptions>;
+
+/** Render an unknown thrown value as a concise, log-friendly reason. */
+function errorReason(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
 }
 
 function normalizeOptions(
@@ -76,16 +84,22 @@ function buildWorkerTargets(
 
 /**
  * Read and validate a wrangler config. Returns its raw content when valid, or
- * null (after warning) when the file is unreadable, an empty .toml, or
- * unparseable json/jsonc. Returning the content lets callers reuse the single
- * read for cache-key hashing instead of reading the file twice.
+ * null (after warning) when the file is unreadable, an empty `.toml`, or
+ * json/jsonc that fails to parse. The gate is structural, not semantic: a
+ * parseable but minimal config (e.g. `{}`) is accepted, since Wrangler
+ * validates its own contents at runtime. `.toml` has no parser here, so
+ * non-empty is the only available proxy for "usable". Returning the content
+ * lets callers reuse the single read for cache-key hashing instead of reading
+ * the file twice.
  */
 function readValidConfig(absConfigPath: string): string | null {
   let content: string;
   try {
     content = readFileSync(absConfigPath, 'utf-8');
   } catch (e) {
-    logger.warn(`[nx-cloudflare] Could not read ${absConfigPath}: ${e}`);
+    logger.warn(
+      `[nx-cloudflare] Could not read ${absConfigPath}: ${errorReason(e)}`
+    );
     return null;
   }
 
@@ -104,24 +118,45 @@ function readValidConfig(absConfigPath: string): string | null {
     return content;
   } catch (e) {
     logger.warn(
-      `[nx-cloudflare] Skipping unparseable wrangler config ${absConfigPath}: ${e}`
+      `[nx-cloudflare] Skipping unparseable wrangler config ${absConfigPath}: ${errorReason(
+        e
+      )}`
     );
     return null;
   }
 }
 
-type TargetsCache = Record<string, Record<string, TargetConfiguration>>;
+type TargetsCache = Record<string, ReturnType<typeof buildWorkerTargets>>;
 
 function readTargetsCache(cachePath: string): TargetsCache {
+  if (!existsSync(cachePath)) {
+    return {};
+  }
+  // A present-but-unreadable cache (corruption, a format change after an Nx
+  // bump, permissions) recomputes targets rather than failing the graph, but
+  // is surfaced so the degraded caching isn't silent.
   try {
-    return existsSync(cachePath) ? readJsonFile(cachePath) : {};
-  } catch {
+    return readJsonFile(cachePath);
+  } catch (e) {
+    logger.warn(
+      `[nx-cloudflare] Ignoring unreadable targets cache ${cachePath}; ` +
+        `recomputing targets. Reason: ${errorReason(e)}`
+    );
     return {};
   }
 }
 
 function writeTargetsCache(cachePath: string, cache: TargetsCache): void {
-  writeJsonFile(cachePath, cache);
+  // The cache is a best-effort optimization: a write failure must neither abort
+  // graph construction nor mask an in-flight error from the caller's try block.
+  try {
+    writeJsonFile(cachePath, cache);
+  } catch (e) {
+    logger.warn(
+      `[nx-cloudflare] Could not write targets cache ${cachePath}; ` +
+        `targets will be recomputed next run. Reason: ${errorReason(e)}`
+    );
+  }
 }
 
 function createNodesInternal(
@@ -139,7 +174,9 @@ function createNodesInternal(
     siblings = readdirSync(join(context.workspaceRoot, projectRoot));
   } catch (e) {
     logger.warn(
-      `[nx-cloudflare] Could not read project directory ${projectRoot}: ${e}`
+      `[nx-cloudflare] Could not read project directory ${projectRoot}: ${errorReason(
+        e
+      )}`
     );
     return {};
   }
@@ -157,10 +194,11 @@ function createNodesInternal(
   }
 
   const normalized = normalizeOptions(options);
+  // The cache file is already partitioned by an options hash (see below), so the
+  // per-entry key only needs to distinguish projects by path and content.
   const cacheKey = createHash('sha256')
     .update(configFile)
     .update(content)
-    .update(JSON.stringify(normalized))
     .digest('hex');
 
   targetsCache[cacheKey] ??= buildWorkerTargets(projectRoot, normalized);
@@ -168,6 +206,13 @@ function createNodesInternal(
   return { projects: { [projectRoot]: { targets: targetsCache[cacheKey] } } };
 }
 
+/**
+ * Nx inference plugin. For every `wrangler.{toml,jsonc,json}` that sits beside a
+ * `project.json`/`package.json` and parses, infers the Worker lifecycle targets
+ * (serve, deploy, typegen, version-upload, tail). The per-config target
+ * calculation is memoized in a cache file under `cacheDir`, keyed by the plugin
+ * options so different option sets never share entries.
+ */
 export const createNodesV2: CreateNodesV2<CloudflarePluginOptions> = [
   '**/wrangler.{toml,jsonc,json}',
   async (configFiles, options, context) => {

--- a/packages/nx-cloudflare/src/plugin.ts
+++ b/packages/nx-cloudflare/src/plugin.ts
@@ -1,12 +1,16 @@
 import { dirname, join } from 'node:path';
-import { readdirSync, readFileSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
 import {
   type CreateNodesContextV2,
   type CreateNodesV2,
   type TargetConfiguration,
+  cacheDir,
   createNodesFromFiles,
   logger,
   parseJson,
+  readJsonFile,
+  writeJsonFile,
 } from '@nx/devkit';
 
 /** Options to rename the inferred Cloudflare Worker targets. */
@@ -71,18 +75,18 @@ function buildWorkerTargets(
 }
 
 /**
- * A wrangler config is "valid enough" to infer targets from when:
- *  - json/jsonc parses (comments allowed), or
- *  - toml is readable and non-empty (toml is legacy; we do not add a parser).
- * Returns false and warns on failure so the project is skipped, not silently.
+ * Read and validate a wrangler config. Returns its raw content when valid, or
+ * null (after warning) when the file is unreadable, an empty .toml, or
+ * unparseable json/jsonc. Returning the content lets callers reuse the single
+ * read for cache-key hashing instead of reading the file twice.
  */
-function configIsValid(absConfigPath: string): boolean {
+function readValidConfig(absConfigPath: string): string | null {
   let content: string;
   try {
     content = readFileSync(absConfigPath, 'utf-8');
   } catch (e) {
     logger.warn(`[nx-cloudflare] Could not read ${absConfigPath}: ${e}`);
-    return false;
+    return null;
   }
 
   if (absConfigPath.endsWith('.toml')) {
@@ -90,26 +94,41 @@ function configIsValid(absConfigPath: string): boolean {
       logger.warn(
         `[nx-cloudflare] Skipping empty wrangler config ${absConfigPath}`
       );
-      return false;
+      return null;
     }
-    return true;
+    return content;
   }
 
   try {
     parseJson(content);
-    return true;
+    return content;
   } catch (e) {
     logger.warn(
       `[nx-cloudflare] Skipping unparseable wrangler config ${absConfigPath}: ${e}`
     );
-    return false;
+    return null;
   }
+}
+
+type TargetsCache = Record<string, Record<string, TargetConfiguration>>;
+
+function readTargetsCache(cachePath: string): TargetsCache {
+  try {
+    return existsSync(cachePath) ? readJsonFile(cachePath) : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeTargetsCache(cachePath: string, cache: TargetsCache): void {
+  writeJsonFile(cachePath, cache);
 }
 
 function createNodesInternal(
   configFile: string,
   options: CloudflarePluginOptions | undefined,
-  context: CreateNodesContextV2
+  context: CreateNodesContextV2,
+  targetsCache: TargetsCache
 ) {
   const projectRoot = dirname(configFile);
 
@@ -123,21 +142,42 @@ function createNodesInternal(
     return {};
   }
 
-  if (!configIsValid(join(context.workspaceRoot, configFile))) {
+  const absConfigPath = join(context.workspaceRoot, configFile);
+  const content = readValidConfig(absConfigPath);
+  if (content === null) {
     return {};
   }
 
-  const targets = buildWorkerTargets(projectRoot, normalizeOptions(options));
-  return { projects: { [projectRoot]: { targets } } };
+  const normalized = normalizeOptions(options);
+  const cacheKey = createHash('sha256')
+    .update(configFile)
+    .update(content)
+    .update(JSON.stringify(normalized))
+    .digest('hex');
+
+  targetsCache[cacheKey] ??= buildWorkerTargets(projectRoot, normalized);
+
+  return { projects: { [projectRoot]: { targets: targetsCache[cacheKey] } } };
 }
 
 export const createNodesV2: CreateNodesV2<CloudflarePluginOptions> = [
   '**/wrangler.{toml,jsonc,json}',
-  (configFiles, options, context) =>
-    createNodesFromFiles(
-      (configFile, opts, ctx) => createNodesInternal(configFile, opts, ctx),
-      configFiles,
-      options,
-      context
-    ),
+  async (configFiles, options, context) => {
+    const optionsHash = createHash('sha256')
+      .update(JSON.stringify(options ?? {}))
+      .digest('hex');
+    const cachePath = join(cacheDir, `nx-cloudflare-${optionsHash}.hash`);
+    const targetsCache = readTargetsCache(cachePath);
+    try {
+      return await createNodesFromFiles(
+        (configFile, opts, ctx) =>
+          createNodesInternal(configFile, opts, ctx, targetsCache),
+        configFiles,
+        options,
+        context
+      );
+    } finally {
+      writeTargetsCache(cachePath, targetsCache);
+    }
+  },
 ];

--- a/packages/nx-cloudflare/src/plugin.ts
+++ b/packages/nx-cloudflare/src/plugin.ts
@@ -1,4 +1,5 @@
-import { dirname } from 'node:path';
+import { dirname, join } from 'node:path';
+import { readdirSync } from 'node:fs';
 import {
   type CreateNodesContextV2,
   type CreateNodesV2,
@@ -69,9 +70,17 @@ function buildWorkerTargets(
 function createNodesInternal(
   configFile: string,
   options: CloudflarePluginOptions | undefined,
-  _context: CreateNodesContextV2
+  context: CreateNodesContextV2
 ) {
   const projectRoot = dirname(configFile);
+
+  // Only infer targets for real Nx projects: a sibling project.json or
+  // package.json. Otherwise this wrangler file is not a project root.
+  const siblings = readdirSync(join(context.workspaceRoot, projectRoot));
+  if (!siblings.includes('project.json') && !siblings.includes('package.json')) {
+    return {};
+  }
+
   const targets = buildWorkerTargets(projectRoot, normalizeOptions(options));
   return { projects: { [projectRoot]: { targets } } };
 }

--- a/packages/nx-cloudflare/src/plugin.ts
+++ b/packages/nx-cloudflare/src/plugin.ts
@@ -1,10 +1,12 @@
 import { dirname, join } from 'node:path';
-import { readdirSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
 import {
   type CreateNodesContextV2,
   type CreateNodesV2,
   type TargetConfiguration,
   createNodesFromFiles,
+  logger,
+  parseJson,
 } from '@nx/devkit';
 
 /** Options to rename the inferred Cloudflare Worker targets. */
@@ -31,7 +33,8 @@ function normalizeOptions(
     serveTargetName: options?.serveTargetName ?? 'serve',
     deployTargetName: options?.deployTargetName ?? 'deploy',
     typegenTargetName: options?.typegenTargetName ?? 'typegen',
-    versionUploadTargetName: options?.versionUploadTargetName ?? 'version-upload',
+    versionUploadTargetName:
+      options?.versionUploadTargetName ?? 'version-upload',
     tailTargetName: options?.tailTargetName ?? 'tail',
   };
 }
@@ -67,6 +70,42 @@ function buildWorkerTargets(
   };
 }
 
+/**
+ * A wrangler config is "valid enough" to infer targets from when:
+ *  - json/jsonc parses (comments allowed), or
+ *  - toml is readable and non-empty (toml is legacy; we do not add a parser).
+ * Returns false and warns on failure so the project is skipped, not silently.
+ */
+function configIsValid(absConfigPath: string): boolean {
+  let content: string;
+  try {
+    content = readFileSync(absConfigPath, 'utf-8');
+  } catch (e) {
+    logger.warn(`[nx-cloudflare] Could not read ${absConfigPath}: ${e}`);
+    return false;
+  }
+
+  if (absConfigPath.endsWith('.toml')) {
+    if (content.trim().length === 0) {
+      logger.warn(
+        `[nx-cloudflare] Skipping empty wrangler config ${absConfigPath}`
+      );
+      return false;
+    }
+    return true;
+  }
+
+  try {
+    parseJson(content);
+    return true;
+  } catch (e) {
+    logger.warn(
+      `[nx-cloudflare] Skipping unparseable wrangler config ${absConfigPath}: ${e}`
+    );
+    return false;
+  }
+}
+
 function createNodesInternal(
   configFile: string,
   options: CloudflarePluginOptions | undefined,
@@ -77,7 +116,14 @@ function createNodesInternal(
   // Only infer targets for real Nx projects: a sibling project.json or
   // package.json. Otherwise this wrangler file is not a project root.
   const siblings = readdirSync(join(context.workspaceRoot, projectRoot));
-  if (!siblings.includes('project.json') && !siblings.includes('package.json')) {
+  if (
+    !siblings.includes('project.json') &&
+    !siblings.includes('package.json')
+  ) {
+    return {};
+  }
+
+  if (!configIsValid(join(context.workspaceRoot, configFile))) {
     return {};
   }
 


### PR DESCRIPTION
## TL;DR

The plugin had no Nx 22 inference, so every Cloudflare Worker project had to hand-write its `serve`/`deploy` targets in `project.json` — the only `plugins/` entry was a Next.js webpack helper, not Crystal. This adds a `createNodesV2` plugin that globs `wrangler.{toml,jsonc,json}` and infers `serve`, `deploy`, `typegen`, `version-upload`, and `tail` targets automatically, registered via `@naxodev/nx-cloudflare/plugin`.

**Files to review (3, +519 / -0):**

| File | Why |
|---|---|
| `packages/nx-cloudflare/src/plugin.ts` *(start here)* | The inference plugin: glob → project guard → config gating → target builder, with a computation cache. |
| `packages/nx-cloudflare/src/plugin.spec.ts` *(new)* | 13 tests driving `createNodesV2` over temp-dir fixtures. |
| `packages/nx-cloudflare/package.json` | Adds the `./plugin` export subpath. |

## Why

Nx 22 plugins infer targets from tool config rather than writing them into `project.json`. This is the keystone of the modernization epic (#115): it unblocks replacing the `serve`/`deploy` executors with inferred run-commands (#137) and adopting `useProjectJson` (#140). Registering `@naxodev/nx-cloudflare/plugin` in `nx.json` gives any project beside a wrangler config its full Worker target set with zero target wiring.

## How

Per matched config, the project root is the config's directory, and targets are emitted only when a sibling `project.json` or `package.json` is present — no phantom projects. The config is then gated: `.json`/`.jsonc` must parse (`parseJson`, comments allowed); `.toml` is accepted when readable and non-empty. A parse failure or an unreadable directory warns and skips that one project.

Each target shells out to the Wrangler CLI via `nx:run-commands` (`command` shorthand), run from the project root so Wrangler resolves its own config:

| Target | Command | Cached | Continuous |
|---|---|:---:|:---:|
| `serve` | `wrangler dev` | — | yes |
| `deploy` | `wrangler deploy` | — | — |
| `typegen` | `wrangler types` | yes | — |
| `version-upload` | `wrangler versions upload` | — | — |
| `tail` | `wrangler tail` | — | yes |

A targets cache memoizes the calculation across graph constructions: one cache file per plugin-options hash, with entries keyed by config path plus content. Cache reads and writes are best-effort — a corrupt or unwritable cache warns and recomputes rather than failing the graph.

## Reviewer notes

- **Run-commands, not executors.** Targets call the Wrangler CLI directly rather than the existing `serve`/`deploy` executors, baking in the #137 end-state so those executors can be removed next.
- **No `build` target.** Wrangler bundles on deploy; a standalone build step is un-Cloudflare, so the only cacheable target is `typegen` (deterministic `worker-configuration.d.ts` output, invalidated by `externalDependencies: ['wrangler']`). `deploy`/`version-upload` have remote side effects; `serve`/`tail` are long-running.
- **Public `@nx/devkit` only.** No `nx/src/*` deep imports — continuing #139. The cache directory uses the public `cacheDir` because `workspaceDataDirectory` isn't exported in the installed Nx 22.7.5.
- **Fail loud, per project.** An unparseable config, an unreadable project directory, or a corrupt/unwritable cache warns and degrades to no-targets-for-that-file or recompute; graph construction for the rest of the workspace continues rather than aborting.
- **Structural gate, not semantic.** A parseable-but-minimal config (e.g. `{}`) is accepted — Wrangler validates its own contents at runtime. Empty `.toml` is rejected only because no TOML parser is bundled, so non-empty is the available proxy for "usable".
- **Target names are configurable** via `CloudflarePluginOptions` (`serveTargetName`, `deployTargetName`, …) to resolve collisions with user-defined targets.

## Tests

13 unit tests in `plugin.spec.ts` over real temp-dir fixtures: the five-target happy path, both project markers, plain `.json` and minimal `{}` configs, no-marker skip, unparseable jsonc, empty toml, valid toml, custom target names, options-keyed caching, multi-config isolation (one valid + one invalid in a single invocation), cross-run cache identity, and graceful skip when the project directory is unreadable. Run with `nx test nx-cloudflare`.

## Links

- Closes #136
- Epic #115
