### PR TITLE
feat(gonx): harden build-constraint context and tree-sitter WASM loading (#108, #113, #104)

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "verdaccio": "6.7.2",
     "vite": "7.3.1",
     "vitest": "4.0.9",
-    "web-tree-sitter": "^0.26.3",
+    "web-tree-sitter": "0.26.3",
     "wrangler": "^4.26.0"
   },
   "dependencies": {

--- a/packages/gonx/docs/static-analysis.md
+++ b/packages/gonx/docs/static-analysis.md
@@ -60,8 +60,9 @@ Supported in the constraint expression:
   in `internal/syslist.UnixOS`)
 - GOOS values (`linux`, `darwin`, `windows`, …) and GOARCH values
   (`amd64`, `arm64`, `386`, …)
-- User-defined tags via the `BuildContext.tags` set (internal API; a
-  plugin-option surface is tracked in [#108](https://github.com/naxodev/oss/issues/108))
+- User-defined tags via the `BuildContext.tags` set, plus `cgo` and `go1.N`
+  policy via `BuildContext.cgoEnabled` / `BuildContext.goVersion` (internal
+  API; not yet exposed as a plugin option)
 
 Filename-based suffixes are also honored, matching Go's `go/build`
 algorithm:
@@ -77,11 +78,11 @@ unix-gated, and neither do we.
 
 Behavior on edge cases:
 
-- `go1.X` version tags evaluate to `true` (we have no Go compiler
+- `go1.X` version tags evaluate to `true` by default (no Go compiler
   handy to consult; over-including is safer than under-including for
-  graph purposes).
-- The `cgo` pseudo-tag evaluates to `false` — static analysis never
-  invokes cgo.
+  graph purposes). Set `BuildContext.goVersion` to gate on `N >= M`.
+- The `cgo` pseudo-tag evaluates to `false` by default — static analysis
+  never invokes cgo. Set `BuildContext.cgoEnabled` to opt in.
 - A malformed expression falls back to "include the file" rather than
   failing graph construction.
 

--- a/packages/gonx/package.json
+++ b/packages/gonx/package.json
@@ -42,7 +42,7 @@
     "chalk": "^4.1.2",
     "@melkeydev/go-blueprint": "0.10.11",
     "p-limit": "^6.2.0",
-    "web-tree-sitter": "^0.26.3",
+    "web-tree-sitter": "0.26.3",
     "tree-sitter-go": "^0.25.0"
   }
 }

--- a/packages/gonx/src/graph/static-analysis/build-constraints.spec.ts
+++ b/packages/gonx/src/graph/static-analysis/build-constraints.spec.ts
@@ -126,7 +126,9 @@ describe('shouldIncludeFile', () => {
       expect(shouldIncludeFile(content, WINDOWS_AMD64)).toBe(false);
     });
 
-    it('treats `go1.X` tags as always satisfied', () => {
+    it('treats `go1.X` tags as satisfied when no goVersion is set', () => {
+      // With no target version handy the matcher over-includes every
+      // `go1.X` tag; `goVersion`-gated behavior is covered separately.
       const content = withConstraint('//go:build go1.22');
       expect(shouldIncludeFile(content, LINUX_AMD64)).toBe(true);
       expect(shouldIncludeFile(content, WINDOWS_AMD64)).toBe(true);
@@ -264,6 +266,113 @@ describe('shouldIncludeFile', () => {
       const content = 'package foo\n\n//go:build windows\n\nimport "fmt"\n';
       expect(shouldIncludeFile(content, LINUX_AMD64)).toBe(true);
     });
+  });
+});
+
+describe('cgo policy via BuildContext.cgoEnabled', () => {
+  it('treats `cgo` as false by default (static analysis never runs cgo)', () => {
+    const content = withConstraint('//go:build cgo');
+    expect(shouldIncludeFile(content, LINUX_AMD64)).toBe(false);
+  });
+
+  it('matches `cgo` when the context opts in with cgoEnabled', () => {
+    const content = withConstraint('//go:build cgo');
+    expect(
+      shouldIncludeFile(content, { ...LINUX_AMD64, cgoEnabled: true })
+    ).toBe(true);
+  });
+
+  it('includes a `!cgo` file by default (cgo off → !cgo true)', () => {
+    // The common case: a pure-Go fallback gated `//go:build !cgo` must
+    // enter the graph, since static analysis never runs cgo. Guards the
+    // `?? false` default against being flipped to `?? true`.
+    const content = withConstraint('//go:build !cgo');
+    expect(shouldIncludeFile(content, LINUX_AMD64)).toBe(true);
+  });
+
+  it('honors `!cgo` against an opted-in context', () => {
+    // `darwin,!cgo` with cgo enabled → darwin AND NOT cgo → false.
+    const content = withConstraint('// +build darwin,!cgo');
+    expect(
+      shouldIncludeFile(content, { ...DARWIN_ARM64, cgoEnabled: true })
+    ).toBe(false);
+  });
+});
+
+describe('Go-version policy via BuildContext.goVersion', () => {
+  it('treats every `go1.N` tag as satisfied when goVersion is unset', () => {
+    const content = withConstraint('//go:build go1.20');
+    expect(shouldIncludeFile(content, LINUX_AMD64)).toBe(true);
+  });
+
+  it('excludes a go1.20-gated file under goVersion 1.18', () => {
+    const content = withConstraint('//go:build go1.20');
+    expect(
+      shouldIncludeFile(content, { ...LINUX_AMD64, goVersion: '1.18' })
+    ).toBe(false);
+  });
+
+  it('includes a go1.20-gated file under goVersion 1.22', () => {
+    const content = withConstraint('//go:build go1.20');
+    expect(
+      shouldIncludeFile(content, { ...LINUX_AMD64, goVersion: '1.22' })
+    ).toBe(true);
+  });
+
+  it('satisfies a go1.18-gated file under goVersion 1.18 (boundary is >=)', () => {
+    const content = withConstraint('//go:build go1.18');
+    expect(
+      shouldIncludeFile(content, { ...LINUX_AMD64, goVersion: '1.18' })
+    ).toBe(true);
+  });
+
+  it('compares versions numerically, not lexically (1.9 does not satisfy go1.10)', () => {
+    // String comparison would put '1.9' > '1.10' and wrongly include.
+    const content = withConstraint('//go:build go1.10');
+    expect(
+      shouldIncludeFile(content, { ...LINUX_AMD64, goVersion: '1.9' })
+    ).toBe(false);
+  });
+
+  it('over-includes (does not exclude) when goVersion is unparseable', () => {
+    // `BuildContext` is an internal API fed from external sources; a
+    // malformed version must NOT silently drop edges. A naive
+    // `Number('x') >= M` is `NaN >= M` → false → exclude, the opposite of
+    // the documented over-include policy. Unparseable behaves like unset.
+    const content = withConstraint('//go:build go1.20');
+    expect(
+      shouldIncludeFile(content, {
+        ...LINUX_AMD64,
+        goVersion: '1.x' as `1.${number}`,
+      })
+    ).toBe(true);
+  });
+
+  it('gates go1.N through the legacy // +build path too', () => {
+    // `go1.N` tags appear in pre-1.17 legacy headers; version policy must
+    // hold regardless of which constraint syntax reaches `matchTag`.
+    const content = withConstraint('// +build go1.20');
+    expect(
+      shouldIncludeFile(content, { ...LINUX_AMD64, goVersion: '1.18' })
+    ).toBe(false);
+    expect(
+      shouldIncludeFile(content, { ...LINUX_AMD64, goVersion: '1.22' })
+    ).toBe(true);
+  });
+
+  it('combines version gating with a GOOS term under &&', () => {
+    // Real headers look like `go1.20 && linux`; the numeric version result
+    // must compose correctly with the boolean evaluator.
+    const content = withConstraint('//go:build go1.20 && linux');
+    expect(
+      shouldIncludeFile(content, { ...LINUX_AMD64, goVersion: '1.18' })
+    ).toBe(false);
+    expect(
+      shouldIncludeFile(content, { ...DARWIN_ARM64, goVersion: '1.22' })
+    ).toBe(false);
+    expect(
+      shouldIncludeFile(content, { ...LINUX_AMD64, goVersion: '1.22' })
+    ).toBe(true);
   });
 });
 
@@ -460,10 +569,34 @@ describe('getDefaultBuildContext', () => {
   });
 
   it('passes unknown Node platforms through unchanged', () => {
-    // Best-effort fallback: a niche Node platform (e.g. cygwin) is
-    // returned as-is. Documented behavior.
+    // Best-effort fallback: a niche Node platform Go has no GOOS for (e.g.
+    // haiku) is returned as-is. Documented behavior.
+    mockedPlatform.mockReturnValue('haiku' as NodeJS.Platform);
+    mockedArch.mockReturnValue('x64');
+    expect(getDefaultBuildContext().goos).toBe('haiku');
+  });
+
+  it('maps cygwin to linux and warns', () => {
+    // Cygwin runs unix-like Go binaries, but Go has no `cygwin` GOOS.
+    // Passing `cygwin` through would exclude `linux`/`unix`-gated files,
+    // violating the over-include policy. Map to linux and warn.
     mockedPlatform.mockReturnValue('cygwin' as NodeJS.Platform);
     mockedArch.mockReturnValue('x64');
-    expect(getDefaultBuildContext().goos).toBe('cygwin');
+    expect(getDefaultBuildContext().goos).toBe('linux');
+    expect(mockedWarn).toHaveBeenCalledWith(expect.stringContaining('cygwin'));
+  });
+
+  it('freezes the returned context so its fields cannot be reassigned', () => {
+    // The shared default is frozen so a caller can't swap `goos`/`tags`
+    // out from under others. The object freeze is the real guarantee here
+    // (it throws on reassignment in strict mode); `tags` immutability is
+    // enforced by its `ReadonlySet` type, since `Object.freeze` does not
+    // lock a Set's contents at runtime.
+    const ctx = getDefaultBuildContext();
+    expect(Object.isFrozen(ctx)).toBe(true);
+    expect(() => {
+      (ctx as { goos: string }).goos = 'windows';
+    }).toThrow();
+    expect(ctx.tags.size).toBe(0);
   });
 });

--- a/packages/gonx/src/graph/static-analysis/build-constraints.ts
+++ b/packages/gonx/src/graph/static-analysis/build-constraints.ts
@@ -12,12 +12,16 @@
  * (`name_<GOOS>.go`, `name_<GOARCH>.go`, `name_<GOOS>_<GOARCH>.go`, with an
  * optional trailing `_test`). See `shouldIncludeFilename`.
  *
- * Known limitations:
- *  - `go1.X` version tags are treated as always-true: we have no compiler
- *    handy to consult, and over-including is safer than under-including
- *    for graph computation. Tracked in #108 (lift policy onto context).
- *  - The pseudo-tag `cgo` is treated as false (static analysis never runs
- *    cgo). Same tracking issue (#108).
+ * Build policy lives on `BuildContext`, not hardcoded in the matcher:
+ *  - `cgo` evaluates to `ctx.cgoEnabled ?? false` — static analysis never
+ *    runs cgo, so it defaults off.
+ *  - `go1.M` version tags evaluate against `ctx.goVersion` when supplied
+ *    (`ctx-minor >= tag-minor`); with no version handy they're treated as
+ *    satisfied, since over-including is safer than under-including for graph
+ *    computation.
+ *
+ * @see https://pkg.go.dev/go/build#hdr-Build_Constraints — the constraint spec this implements
+ * @see https://go.googlesource.com/proposal/+/master/design/draft-gobuild.md — why `//go:build` replaced `// +build`
  */
 
 import { logger } from '@nx/devkit';
@@ -30,6 +34,11 @@ import { platform, arch } from 'os';
 // is a single-line change. The exported `GoOS` adds a `(string & {})` escape
 // hatch so unknown Node platforms still pass through `nodePlatformToGoos`
 // without losing autocomplete on the canonical set.
+//
+// The `(string & {})` open-union trick keeps autocomplete on the known set; the
+// value lists mirror Go's `internal/syslist`.
+// @see https://github.com/microsoft/TypeScript/issues/29729
+// @see https://github.com/golang/go/blob/master/src/internal/syslist/syslist.go
 
 /** Canonical Go `GOOS` values per `internal/syslist.KnownOS`. */
 const KNOWN_GOOSES_LIST = [
@@ -128,14 +137,29 @@ export interface BuildContext {
   readonly goarch: GoArch;
   /** User-supplied tags (e.g. `integration`, `debug`). Default empty. */
   readonly tags: ReadonlySet<string>;
+  /**
+   * Whether cgo is enabled in the target environment. Static analysis never
+   * invokes cgo, so the matcher treats this as `false` when unset — a
+   * `//go:build cgo` file is excluded unless a caller opts in.
+   */
+  readonly cgoEnabled?: boolean;
+  /**
+   * Target Go toolchain version as `1.N`. A `go1.M` build tag means "requires
+   * Go 1.M or newer"; when `goVersion` is set the matcher gates on `N >= M`
+   * (compared numerically). When unset, every `go1.M` tag is satisfied, since
+   * over-including is safer than under-including for graph computation.
+   *
+   * @see https://pkg.go.dev/go/build#hdr-Build_Constraints — `go1.N` release tags
+   */
+  readonly goVersion?: `1.${number}`;
 }
 
 /**
  * Mapping from Node's `process.platform` to Go's GOOS. Keys are constrained
  * to `NodeJS.Platform` and values to `KnownGoOS`, so a typo on either side is
  * a compile error. Entries are listed only for platforms Go's `internal/syslist`
- * actually recognizes — others (e.g. Node's `haiku`, `cygwin`) fall through to
- * the original value in `nodePlatformToGoos`.
+ * actually recognizes — others (e.g. Node's `haiku`) fall through to the
+ * original value in `nodePlatformToGoos`, which special-cases `cygwin`.
  */
 const NODE_PLATFORM_TO_GOOS: Readonly<
   Partial<Record<NodeJS.Platform, KnownGoOS>>
@@ -170,7 +194,17 @@ const NODE_ARCH_TO_GOARCH: Readonly<Record<string, KnownGoArch>> = {
 };
 
 function nodePlatformToGoos(p: NodeJS.Platform): GoOS {
-  // Best-effort: unknown Node platforms (e.g. cygwin, haiku) pass through.
+  // Cygwin runs unix-like Go binaries, but Go has no `cygwin` GOOS. Passing
+  // it through would exclude `linux`/`unix`-gated files, violating the
+  // over-include policy on cygwin hosts. Map to linux (the closest GOOS) and
+  // warn so the substitution is visible.
+  if (p === 'cygwin') {
+    logger.warn(
+      'Detected cygwin Node host; mapping to linux for Go build-constraint evaluation.'
+    );
+    return 'linux';
+  }
+  // Best-effort: other unknown Node platforms (e.g. haiku) pass through.
   return NODE_PLATFORM_TO_GOOS[p] ?? p;
 }
 
@@ -180,14 +214,20 @@ function nodeArchToGoarch(a: string): GoArch {
 
 /**
  * Derive a default `BuildContext` from the current Node process.
- * The result is process-stable — safe to memoize at module level.
+ * The result is process-stable — safe to memoize at module level (the sole
+ * caller does). Freezing the object stops a caller reassigning a field of the
+ * shared default; the `tags` set's immutability is the job of its
+ * `ReadonlySet` type, since `Object.freeze` does not lock a Set's contents at
+ * runtime (the empty-set freeze is a harmless backstop, not the guarantee).
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze — `Object.freeze` does not lock a Set's contents
  */
 export function getDefaultBuildContext(): BuildContext {
-  return {
+  return Object.freeze({
     goos: nodePlatformToGoos(platform()),
     goarch: nodeArchToGoarch(arch()),
-    tags: new Set(),
-  };
+    tags: Object.freeze(new Set<string>()),
+  });
 }
 
 /**
@@ -521,11 +561,33 @@ function matchTag(tag: string, ctx: BuildContext): boolean {
   if (tag === ctx.goos) return true;
   if (tag === ctx.goarch) return true;
   if (tag === 'unix' && UNIX_OSES.has(ctx.goos)) return true;
-  // Go-version tags: assume the user's compiler satisfies them. Over-
-  // including is safer than under-including for graph purposes.
-  if (/^go1\.\d+$/.test(tag)) return true;
-  // We never invoke cgo from static analysis.
-  if (tag === 'cgo') return false;
+  const goVersion = /^go1\.(\d+)$/.exec(tag);
+  if (goVersion) {
+    return satisfiesGoVersion(ctx.goVersion, Number(goVersion[1]));
+  }
+  if (tag === 'cgo') return ctx.cgoEnabled ?? false;
   if (ctx.tags.has(tag)) return true;
   return false;
+}
+
+/**
+ * Evaluate a `go1.M` tag (its minor version) against the context's Go version.
+ * An unset `ctx.goVersion` satisfies every tag (over-include); a set version
+ * gates on `ctx-minor >= tag-minor`, compared numerically so `1.9` correctly
+ * fails `go1.10` (lexical comparison would wrongly include it).
+ *
+ * The `\`1.${number}\`` type can be subverted at an `as` boundary or once
+ * `goVersion` is fed from external config, yielding an unparseable value. We
+ * over-include in that case rather than letting `Number('x') >= M` (`NaN >= M`,
+ * always false) silently drop the file — under-including is the worse failure.
+ * Validation of a user-facing `goVersion` belongs at that future input boundary.
+ */
+function satisfiesGoVersion(
+  goVersion: BuildContext['goVersion'],
+  tagMinor: number
+): boolean {
+  if (goVersion === undefined) return true;
+  const parsed = /^1\.(\d+)$/.exec(goVersion);
+  if (!parsed) return true;
+  return Number(parsed[1]) >= tagMinor;
 }

--- a/packages/gonx/src/graph/static-analysis/parser-init.spec.ts
+++ b/packages/gonx/src/graph/static-analysis/parser-init.spec.ts
@@ -1,0 +1,38 @@
+// Contract test for the tree-sitter WASM bytes-loading workaround (#104).
+//
+// This suite deliberately does NOT mock `web-tree-sitter`. The whole reason
+// `parser-init` reads the WASM file itself and passes a `Uint8Array` to
+// `Language.load` is that web-tree-sitter's own dynamic `import()` of the WASM
+// URL throws under Jest's VM (ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING_FLAG).
+// These tests pin that the real bytes overload works and yields a functioning
+// Go parser, so a `web-tree-sitter` upgrade that drops or changes that overload
+// fails loudly here instead of silently breaking graph construction.
+
+import { initParser, resetParser } from './parser-init';
+
+afterEach(() => {
+  resetParser();
+});
+
+describe('initParser (WASM bytes-loading contract)', () => {
+  it('loads the Go grammar from bytes and parses a Go source file', async () => {
+    const parser = await initParser();
+
+    const tree = parser.parse('package main\n\nimport "fmt"\n');
+    if (!tree) throw new Error('expected a parse tree from valid Go source');
+
+    const root = tree.rootNode;
+    expect(root.type).toBe('source_file');
+    expect(root.hasError).toBe(false);
+    // The grammar actually loaded — a real import declaration is recognized.
+    expect(
+      root.namedChildren.some((child) => child?.type === 'import_declaration')
+    ).toBe(true);
+  });
+
+  it('reuses the same parser instance across calls (singleton)', async () => {
+    const first = await initParser();
+    const second = await initParser();
+    expect(second).toBe(first);
+  });
+});

--- a/packages/gonx/src/graph/static-analysis/parser-init.ts
+++ b/packages/gonx/src/graph/static-analysis/parser-init.ts
@@ -70,6 +70,13 @@ async function doInit(): Promise<Parser> {
     // `new Uint8Array` wrap converts Node's `Buffer` (typed as
     // `Uint8Array<ArrayBufferLike>`) into the `Uint8Array<ArrayBuffer>` the
     // signature expects.
+    //
+    // This couples us to the `Language.load(bytes)` overload. `web-tree-sitter`
+    // is pinned to an exact version in package.json, and `parser-init.spec.ts`
+    // contract-tests this path against the real library so a breaking upgrade
+    // fails loudly instead of silently.
+    //
+    // @see https://jestjs.io/docs/ecmascript-modules — the Jest VM/ESM limitation behind the workaround
     const wasmBytes = new Uint8Array(readFileSync(wasmPath));
     Go = await Language.load(wasmBytes);
   } catch (error) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -262,7 +262,7 @@ importers:
         specifier: 4.0.9
         version: 4.0.9(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@20.12.12)(@vitest/ui@4.0.9)(jiti@2.4.2)(jsdom@22.1.0)(less@4.2.2)(sass-embedded@1.86.3)(sass@1.86.3)(stylus@0.64.0)(terser@5.39.0)(tsx@4.19.4)(yaml@2.9.0)
       web-tree-sitter:
-        specifier: ^0.26.3
+        specifier: 0.26.3
         version: 0.26.3
       wrangler:
         specifier: ^4.26.0
@@ -4952,6 +4952,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -7457,11 +7458,12 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
@@ -10692,6 +10694,7 @@ packages:
   sitemap@8.0.0:
     resolution: {integrity: sha512-+AbdxhM9kJsHtruUF39bwS/B0Fytw6Fr1o4ZAIAEqA6cke2xcoO2GleBw9Zw7nRzILVEgz7zBM5GiTJjie1G9A==}
     engines: {node: '>=14.0.0', npm: '>=6.0.0'}
+    deprecated: 'SECURITY: Multiple vulnerabilities fixed in 8.0.1 (XML injection, path traversal, command injection, protocol injection). Upgrade immediately: npm install sitemap@8.0.1'
     hasBin: true
 
   slash@3.0.0:
@@ -11943,10 +11946,12 @@ packages:
   whatwg-encoding@2.0.0:
     resolution: {integrity: sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==}
     engines: {node: '>=12'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}


### PR DESCRIPTION
## TL;DR

Three follow-ups from PR #106's review hardened the Go build-constraint analyzer: policy (`cgo`, Go version) was hardcoded inside `matchTag` and invisible from the type; the shared default `BuildContext` was mutable and mapped cygwin to a non-existent GOOS; and the tree-sitter WASM bytes-loading workaround had zero test coverage. This PR lifts that policy onto `BuildContext`, freezes the default context (mapping cygwin → linux with a warning), and adds a contract test pinning `Language.load(Uint8Array)` against an exact-pinned `web-tree-sitter`.

**Files to review (8, +266 / -32):**

| File | Why |
|---|---|
| `packages/gonx/src/graph/static-analysis/build-constraints.ts` *(start here)* | `BuildContext` gains `cgoEnabled`/`goVersion`; `matchTag` becomes pure; `getDefaultBuildContext` is frozen and cygwin-aware. |
| `packages/gonx/src/graph/static-analysis/build-constraints.spec.ts` | New cgo/Go-version/freeze/cygwin tests; the old cygwin pass-through test is rewritten to the new behavior. |
| `packages/gonx/src/graph/static-analysis/parser-init.spec.ts` *(new)* | Contract test for the real WASM bytes path under Jest — the existing suite mocks `web-tree-sitter`. |
| `packages/gonx/src/graph/static-analysis/parser-init.ts` | Documents the `Language.load(bytes)` coupling and the pin/contract-test guarding it. |
| `package.json`, `packages/gonx/package.json` | Pin `web-tree-sitter` to exact `0.26.3` (repo resolution + published manifest). |
| `packages/gonx/docs/static-analysis.md` | Corrects a doc anchor and documents the new context fields. |

## Why

These three issues were surfaced by PR #106's review and tracked as follow-ups (#108, #113, #104). Five sibling issues from the same review (#107, #109, #110, #111, #112) were already satisfied by code that landed inside #106 and are now closed; this PR covers the remainder.

The concrete problems: a caller could not model "cgo is enabled" or "this code compiles under Go 1.18" — `matchTag` answered `cgo → false` and `go1.X → true` unconditionally. The default context was a plain mutable object shared process-wide, and `cygwin` passed through as a GOOS Go doesn't have, so `linux`/`unix`-gated files were wrongly excluded on cygwin hosts. And the WASM workaround — reading bytes ourselves to dodge Jest's dynamic-import failure — was exercised only through mocks, so an upstream change to the bytes overload would have broken graph construction silently.

## How

- **Policy onto the context (#108).** `BuildContext` gains optional `cgoEnabled?: boolean` and a `goVersion?` field typed `1.${number}`. `matchTag` now reads `cgo → ctx.cgoEnabled ?? false` and evaluates `go1.M` against `ctx.goVersion` (satisfied when unset). Defaults reproduce today's behavior exactly.
- **Harden the default (#113).** `getDefaultBuildContext` returns an `Object.freeze`'d context with a frozen tags set; `nodePlatformToGoos` special-cases `cygwin → linux` and warns once.
- **Contract-test the WASM path (#104).** A new `parser-init.spec.ts` loads the real grammar from bytes and parses Go, with `web-tree-sitter` pinned to exact `0.26.3` so the overload can't drift unseen.

## Reviewer notes

- **Default behavior is unchanged.** With `cgoEnabled`/`goVersion` unset and no cygwin host, every existing result is identical — the 44 prior `build-constraints` tests pass untouched. The new fields are purely additive opt-ins.
- **Go versions compare numerically, not lexically.** `go1.10` under `goVersion: '1.9'` must be *unsatisfied* (9 < 10); a string compare would put `'1.9' > '1.10'` and wrongly include. A test pins this.
- **`Object.freeze` on a Set is partial by design.** It makes `Object.isFrozen` true and blocks property addition, but the real immutability guarantee for `tags` is the compile-time `ReadonlySet<string>`; freeze is the runtime backstop the issue asked for.
- **The cygwin warning fires once.** `extract-imports.ts` memoizes the default context at module load, so the `logger.warn` is emitted a single time per process, not per file.
- **The contract test deliberately un-mocks `web-tree-sitter`.** That is the point — it runs the exact bytes path production uses under Jest, so a breaking upgrade fails loudly here instead of silently dropping edges.
- **A malformed `goVersion` over-includes, never excludes.** The `` `1.${number}` `` type can be subverted via `as`/external config; `satisfiesGoVersion` validates `/^1\.\d+$/` and falls back to satisfy-all rather than letting `NaN >= M` silently drop edges — honoring the over-include policy. Validation of a user-facing `goVersion` belongs at that future input boundary.

## Tests

`nx test gonx` → 278 passed (27 suites). New: cgo defaults (incl. `!cgo`), Go-version policy (numeric boundary, legacy `// +build` path, `&&` composition, unparseable over-include), cygwin/freeze, and the WASM contract cases. `tsc --noEmit` clean; `eslint` 0 errors.

## Links

- [#108 — lift cgo/Go-version policy onto BuildContext](https://github.com/naxodev/oss/issues/108)
- [#113 — freeze default context + cygwin handling](https://github.com/naxodev/oss/issues/113)
- [#104 — harden WASM loading for tree-sitter under Jest](https://github.com/naxodev/oss/issues/104)
- Parent review: [#106](https://github.com/naxodev/oss/pull/106)
