### PR TITLE
fix(nx-cloudflare): strip dangling @nx/node prune targets from generated worker projects (#163)

### DIFF
--- a/packages/nx-cloudflare/src/generators/application/generator.spec.ts
+++ b/packages/nx-cloudflare/src/generators/application/generator.spec.ts
@@ -35,6 +35,49 @@ describe('app', () => {
       expect(project.targets?.deploy).toBeUndefined();
       // No build target: wrangler bundles on deploy.
       expect(project.targets?.build).toBeUndefined();
+      // @nx/node's Node deployment helpers dangle once build is gone (they
+      // dependsOn build) and are meaningless for a Worker, so they are stripped.
+      expect(project.targets?.prune).toBeUndefined();
+      expect(project.targets?.['prune-lockfile']).toBeUndefined();
+      expect(project.targets?.['copy-workspace-modules']).toBeUndefined();
+    });
+
+    it('keeps the lint target that the worker still needs', async () => {
+      // The strip list is an allowlist of node-app targets that don't apply to
+      // a Worker; flipping it to a denylist (or an over-broad loop) would also
+      // wipe lint/test. Lock in that a kept target survives.
+      await applicationGenerator(tree, {
+        name: 'myWorkerApp',
+        directory: 'myWorkerApp',
+      });
+      const project = readProjectConfiguration(tree, 'myWorkerApp');
+      expect(project.targets?.lint).toBeDefined();
+    });
+
+    it('leaves no surviving target depending on a stripped one', async () => {
+      // The bug this guards: a future @nx/node version could add another
+      // build-dependent target outside the allowlist, silently reintroducing a
+      // dangling dependsOn. Assert structurally that nothing left in the project
+      // depends on a target we removed, rather than naming today's targets.
+      await applicationGenerator(tree, {
+        name: 'myWorkerApp',
+        directory: 'myWorkerApp',
+      });
+      const project = readProjectConfiguration(tree, 'myWorkerApp');
+      const stripped = [
+        'build',
+        'serve',
+        'prune',
+        'prune-lockfile',
+        'copy-workspace-modules',
+      ];
+      for (const target of Object.values(project.targets ?? {})) {
+        for (const dep of target.dependsOn ?? []) {
+          const depTarget =
+            typeof dep === 'string' ? dep.replace(/^\^/, '') : dep.target;
+          expect(stripped).not.toContain(depTarget);
+        }
+      }
     });
 
     it('writes the requested port into the wrangler config dev.port', async () => {

--- a/packages/nx-cloudflare/src/generators/application/generator.ts
+++ b/packages/nx-cloudflare/src/generators/application/generator.ts
@@ -156,17 +156,40 @@ function addCloudflareFiles(tree: Tree, options: NormalizedSchema) {
   }
 }
 
-// Strip the executor targets the node application generator adds. Wrangler
-// bundles on deploy, so Worker projects have no separate build step, and the
-// node generator's @nx/js:node `serve` would shadow the inferred one. serve,
-// deploy and the rest are inferred by the createNodesV2 plugin (see plugin.ts).
+// The @nx/node application generator adds Node-oriented targets that don't
+// apply to a Cloudflare Worker. Wrangler bundles on deploy, so there is no
+// separate `build` step; the @nx/js:node `serve` would shadow the inferred one;
+// and `prune`/`prune-lockfile`/`copy-workspace-modules` are Node deployment
+// helpers that `dependsOn: ['build']` and would dangle once `build` is gone.
+// serve, deploy and the Worker lifecycle targets are inferred by the
+// createNodesV2 plugin instead (see plugin.ts). `lint`/`test` are kept.
+// This list is coupled to @nx/node's emitted targets; a generator test asserts
+// no surviving target depends on a stripped one, so a new build-dependent
+// target in a future @nx/node would fail CI rather than dangle silently.
+const NODE_APP_TARGETS_TO_REMOVE = [
+  'build',
+  'serve',
+  'prune',
+  'prune-lockfile',
+  'copy-workspace-modules',
+] as const;
+
 function removeNodeAppTargets(tree: Tree, options: NormalizedSchema) {
   const projectConfiguration = readProjectConfiguration(tree, options.name);
   const targets = projectConfiguration.targets;
+  if (!targets) {
+    return;
+  }
 
-  if (targets?.build || targets?.serve) {
-    delete targets.build;
-    delete targets.serve;
+  let changed = false;
+  for (const target of NODE_APP_TARGETS_TO_REMOVE) {
+    if (targets[target]) {
+      delete targets[target];
+      changed = true;
+    }
+  }
+
+  if (changed) {
     updateProjectConfiguration(tree, options.name, projectConfiguration);
   }
 }


### PR DESCRIPTION
## TL;DR

The application generator already strips `@nx/node`'s `build`/`serve` targets, but `@nx/node` *also* emits `prune`, `prune-lockfile`, and `copy-workspace-modules` — all `dependsOn: ['build']`. With `build` deleted these dangle (`nx prune <app>` can't resolve its dep) and are meaningless for a Worker anyway, since Wrangler bundles on deploy. This extends `removeNodeAppTargets` to delete them too.

## Why

Pre-existing leftover, not introduced here — the old `addTargets` also deleted `build` while leaving these three. But #137's goal is a coherent inferred-target Worker project, and these Node deployment helpers undercut it: they reference a target that no longer exists.

Confirmed against `@nx/node@22.7.5` source: its application generator unconditionally emits `build`, `serve`, `prune-lockfile`, `copy-workspace-modules`, and `prune` (the prune chain all `dependsOn` `build`), and exposes **no** option (`bundler`/`framework`) to suppress them — so stripping by name after generation is the only available approach.

## How

`removeNodeAppTargets` now deletes an explicit allowlist of the `@nx/node` app targets that don't apply to a Worker — `build`, `serve`, `prune`, `prune-lockfile`, `copy-workspace-modules` — and keeps `lint`/`test`. The allowlist is a named constant so the intent (and what's deliberately kept) is legible.

## Reviewer notes

- **The allowlist is coupled to `@nx/node`'s target set.** A future `@nx/node` that adds another build-dependent target would silently reintroduce this exact dangling-target bug. Guarded by a structural test (below) that fails CI if any surviving target depends on a stripped one, rather than relying on the list staying hand-synced.

## Tests

Three assertions, covering both failure directions of an allowlist:
1. The existing "without executor targets" test now also asserts `prune`/`prune-lockfile`/`copy-workspace-modules` are absent. Verified non-vacuous: with the three removed from the allowlist the test fails (`@nx/node` does emit them).
2. A new test asserts `lint` is **kept** — guards against the allowlist degrading into a denylist/over-broad loop that wipes targets the Worker still needs.
3. A new structural test asserts no surviving target `dependsOn` a stripped one — the future-`@nx/node` guard described above.

30 unit tests pass; lint and format clean.

## Links

- Closes #163
- Follow-up from #137 (#162) · Part of #115
