### PR TITLE
refactor(nx-cloudflare): drop the createNodesV2 targets-cache (#164)

### DIFF
--- a/packages/nx-cloudflare/src/plugin.spec.ts
+++ b/packages/nx-cloudflare/src/plugin.spec.ts
@@ -196,19 +196,6 @@ describe('nx-cloudflare createNodesV2', () => {
     warn.mockRestore();
   });
 
-  it('returns identical targets across repeated runs (cache safe)', async () => {
-    writeFile(workspaceRoot, 'apps/worker/project.json', '{"name":"worker"}');
-    writeFile(workspaceRoot, 'apps/worker/wrangler.jsonc', '{"name":"worker"}');
-
-    const first = await run(workspaceRoot, 'apps/worker/wrangler.jsonc');
-    const second = await run(workspaceRoot, 'apps/worker/wrangler.jsonc');
-
-    expect(second).toEqual(first);
-    expect(second.projects['apps/worker'].targets.typegen).toMatchObject({
-      cache: true,
-    });
-  });
-
   it('infers targets for a plain wrangler.json (non-jsonc) config', async () => {
     // The glob matches `.json` too; it takes the same parse path as `.jsonc`.
     writeFile(workspaceRoot, 'apps/jsonworker/project.json', '{"name":"jw"}');
@@ -235,10 +222,9 @@ describe('nx-cloudflare createNodesV2', () => {
     });
   });
 
-  it('reflects plugin options in cached targets, not just config content', async () => {
-    // Why: same config content, different options. If the cache keyed on
-    // content alone, the second run would be served the first run's
-    // default-named targets. Guards the options->cache-path keying.
+  it('reflects plugin options in target names, not just config content', async () => {
+    // Why: same config content, different options must yield differently named
+    // targets. Guards that options flow through to the inferred target set.
     writeFile(workspaceRoot, 'apps/worker/project.json', '{"name":"worker"}');
     writeFile(workspaceRoot, 'apps/worker/wrangler.jsonc', '{"name":"worker"}');
 
@@ -256,7 +242,7 @@ describe('nx-cloudflare createNodesV2', () => {
   });
 
   it('handles multiple configs in one invocation, isolating failures', async () => {
-    // Why: the real entry point receives many files sharing one cache. A bad
+    // Why: the real entry point receives many files in one invocation. A bad
     // config must degrade to {} without taking down a valid sibling.
     const warn = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
     writeFile(workspaceRoot, 'apps/a/project.json', '{"name":"a"}');

--- a/packages/nx-cloudflare/src/plugin.ts
+++ b/packages/nx-cloudflare/src/plugin.ts
@@ -1,16 +1,12 @@
 import { dirname, join } from 'node:path';
-import { existsSync, readdirSync, readFileSync } from 'node:fs';
-import { createHash } from 'node:crypto';
+import { readdirSync, readFileSync } from 'node:fs';
 import {
   type CreateNodesContextV2,
   type CreateNodesV2,
   type TargetConfiguration,
-  cacheDir,
   createNodesFromFiles,
   logger,
   parseJson,
-  readJsonFile,
-  writeJsonFile,
 } from '@nx/devkit';
 
 /** Options to rename the inferred Cloudflare Worker targets. */
@@ -97,9 +93,8 @@ function buildWorkerTargets(
  * json/jsonc that fails to parse. The gate is structural, not semantic: a
  * parseable but minimal config (e.g. `{}`) is accepted, since Wrangler
  * validates its own contents at runtime. `.toml` has no parser here, so
- * non-empty is the only available proxy for "usable". Returning the content
- * lets callers reuse the single read for cache-key hashing instead of reading
- * the file twice.
+ * non-empty is the only available proxy for "usable". The validated content is
+ * returned (callers treat it as a truthy validity signal).
  */
 function readValidConfig(absConfigPath: string): string | null {
   let content: string;
@@ -135,44 +130,10 @@ function readValidConfig(absConfigPath: string): string | null {
   }
 }
 
-type TargetsCache = Record<string, ReturnType<typeof buildWorkerTargets>>;
-
-function readTargetsCache(cachePath: string): TargetsCache {
-  if (!existsSync(cachePath)) {
-    return {};
-  }
-  // A present-but-unreadable cache (corruption, a format change after an Nx
-  // bump, permissions) recomputes targets rather than failing the graph, but
-  // is surfaced so the degraded caching isn't silent.
-  try {
-    return readJsonFile(cachePath);
-  } catch (e) {
-    logger.warn(
-      `[nx-cloudflare] Ignoring unreadable targets cache ${cachePath}; ` +
-        `recomputing targets. Reason: ${errorReason(e)}`
-    );
-    return {};
-  }
-}
-
-function writeTargetsCache(cachePath: string, cache: TargetsCache): void {
-  // The cache is a best-effort optimization: a write failure must neither abort
-  // graph construction nor mask an in-flight error from the caller's try block.
-  try {
-    writeJsonFile(cachePath, cache);
-  } catch (e) {
-    logger.warn(
-      `[nx-cloudflare] Could not write targets cache ${cachePath}; ` +
-        `targets will be recomputed next run. Reason: ${errorReason(e)}`
-    );
-  }
-}
-
 function createNodesInternal(
   configFile: string,
   options: CloudflarePluginOptions | undefined,
-  context: CreateNodesContextV2,
-  targetsCache: TargetsCache
+  context: CreateNodesContextV2
 ) {
   const projectRoot = dirname(configFile);
 
@@ -197,49 +158,28 @@ function createNodesInternal(
   }
 
   const absConfigPath = join(context.workspaceRoot, configFile);
-  const content = readValidConfig(absConfigPath);
-  if (content === null) {
+  if (readValidConfig(absConfigPath) === null) {
     return {};
   }
 
-  const normalized = normalizeOptions(options);
-  // The cache file is already partitioned by an options hash (see below), so the
-  // per-entry key only needs to distinguish projects by path and content.
-  const cacheKey = createHash('sha256')
-    .update(configFile)
-    .update(content)
-    .digest('hex');
-
-  targetsCache[cacheKey] ??= buildWorkerTargets(projectRoot, normalized);
-
-  return { projects: { [projectRoot]: { targets: targetsCache[cacheKey] } } };
+  const targets = buildWorkerTargets(projectRoot, normalizeOptions(options));
+  return { projects: { [projectRoot]: { targets } } };
 }
 
 /**
  * Nx inference plugin. For every `wrangler.{toml,jsonc,json}` that sits beside a
  * `project.json`/`package.json` and parses, infers the Worker lifecycle targets
- * (serve, deploy, typegen, version-upload, tail). The per-config target
- * calculation is memoized in a cache file under `cacheDir`, keyed by the plugin
- * options so different option sets never share entries.
+ * (serve, deploy, typegen, version-upload, tail). Inference is intentionally
+ * uncached. Official Nx plugins (@nx/vite, @nx/eslint, @nx/jest) memoize their
+ * createNodesV2 targets in a `workspaceDataDirectory` cache keyed by a project
+ * file + lockfile hash, but the work here is trivial — per config a dir read,
+ * one config read+parse, and building a small static targets object — so a
+ * cache earns only marginal speed while adding staleness risk across plugin
+ * upgrades (no key can capture a change in this code's target-construction
+ * logic). `@naxodev/gonx`'s createNodesV2 is likewise uncached.
  */
 export const createNodesV2: CreateNodesV2<CloudflarePluginOptions> = [
   '**/wrangler.{toml,jsonc,json}',
-  async (configFiles, options, context) => {
-    const optionsHash = createHash('sha256')
-      .update(JSON.stringify(options ?? {}))
-      .digest('hex');
-    const cachePath = join(cacheDir, `nx-cloudflare-${optionsHash}.hash`);
-    const targetsCache = readTargetsCache(cachePath);
-    try {
-      return await createNodesFromFiles(
-        (configFile, opts, ctx) =>
-          createNodesInternal(configFile, opts, ctx, targetsCache),
-        configFiles,
-        options,
-        context
-      );
-    } finally {
-      writeTargetsCache(cachePath, targetsCache);
-    }
-  },
+  (configFiles, options, context) =>
+    createNodesFromFiles(createNodesInternal, configFiles, options, context),
 ];


### PR DESCRIPTION
## TL;DR

The `createNodesV2` inference plugin memoized computed targets in a `.nx/cache` file keyed by config path+content and plugin options — but **not** the plugin's own code version. So upgrading `@naxodev/nx-cloudflare` to a version that changes the inferred targets served stale targets until `nx reset`. This drops the cache entirely.

## Why

The staleness is not hypothetical: it surfaced while implementing #137 — editing `buildWorkerTargets` (adding `serve`'s `readyWhen`) returned a prior run's cached targets until the cache file was manually cleared, because the key can't capture "the plugin's logic changed."

Two fixes were possible: version the cache key, or drop the cache. Dropping wins here because the cache we had was both **non-idiomatic** and **cheap to do without**:

- **It was non-idiomatic.** Official Nx plugins that cache inference (`@nx/vite`, `@nx/eslint`, `@nx/jest`) store under `workspaceDataDirectory` and key via `calculateHashesForCreateNodes` — a project-file hash **plus the lockfile** plus the options hash. Ours stored under `cacheDir` and keyed only on `configFile + content` (no lockfile). The lockfile component is what gives the official caches *de facto* upgrade-invalidation (a plugin bump almost always moves the lockfile hash); ours lacked it, so it was strictly more stale-prone than the upstream pattern.
- **Inference here is trivial.** Per config: one `dirname`, one directory read for the project-marker guard, one config read+parse to validate, and building a small static targets object. The cache bought marginal speed for real staleness risk plus `readTargetsCache`/`writeTargetsCache` complexity.

This is a deliberate divergence from the official cache-the-targets pattern, justified by the trivial cost — not a claim that caching is wrong in general. `@naxodev/gonx`'s `createNodesV2` is likewise uncached, so this also aligns the two plugins.

## How

`createNodesV2` now calls `createNodesFromFiles(createNodesInternal, ...)` directly — no cache file, no try/finally. `createNodesInternal` builds targets inline. Removes the `readTargetsCache`/`writeTargetsCache` helpers, the `TargetsCache` type, and the `cacheDir`/`node:crypto`/`readJsonFile`/`writeJsonFile`/`existsSync` plumbing.

## Tests

12 unit tests pass; lint and build clean. The two cache-framed specs are reworded to assert the underlying invariants (options flow through to target names; multi-config isolation) without referencing the removed cache. The old "repeated runs (cache safe)" test is dropped — with no cache, `createNodesInternal` is a pure function of its inputs, so re-run equality is tautological and can't fail on any plausible logic change (the `typegen.cache: true` assertion it carried is already covered by the richer five-target test). No behavior change to the inferred targets themselves.

## Links

- Closes #164
- Cache originated in #136 (#158); staleness surfaced in #137 (#162) · Part of #115
